### PR TITLE
Auth strategy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,5 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 export * from './smartConfig';
+export * from './smartStrategy';
 export * from './smartHandler';

--- a/src/smartConfig.ts
+++ b/src/smartConfig.ts
@@ -42,7 +42,7 @@ export interface SMARTConfig {
     /**
      * The authorization strategy to use to validate access
      */
-    authStrategies: AuthStrategy[];
+    authStrategies?: AuthStrategy[];
 }
 
 export type AccessModifier = 'read' | 'write';

--- a/src/smartConfig.ts
+++ b/src/smartConfig.ts
@@ -3,6 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 import { TypeOperation, SystemOperation } from 'fhir-works-on-aws-interface';
+import { AuthStrategy } from './smartStrategy';
 
 export interface SMARTConfig {
     version: number;
@@ -38,6 +39,10 @@ export interface SMARTConfig {
      * OAuth2 standard URL used to verify the access_token and get all user claims
      */
     authZUserInfoUrl: string;
+    /**
+     * The authorization strategy to use to validate access
+     */
+    authStrategies: AuthStrategy[];
 }
 
 export type AccessModifier = 'read' | 'write';

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -7,6 +7,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { AuthorizationRequest, SystemOperation, TypeOperation, UnauthorizedError } from 'fhir-works-on-aws-interface';
 import { SMARTHandler } from './smartHandler';
 import { SMARTConfig, ScopeRule } from './smartConfig';
+import { TokenIntrospectionStrategy } from './smartStrategy';
 
 const allReadOperations: (TypeOperation | SystemOperation)[] = [
     'read',
@@ -86,6 +87,7 @@ const authZConfig: SMARTConfig = {
     expectedFhirUserClaimKey: 'fhirUser',
     fhirUserClaimRegex: /(\w+)\/(\w+)/g,
     authZUserInfoUrl: `${expectedIss}/userInfo`,
+    authStrategies: [new TokenIntrospectionStrategy(`${expectedIss}/userInfo`, 'fhirUser')],
 };
 
 const mock = new MockAdapter(axios);

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -7,7 +7,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { AuthorizationRequest, SystemOperation, TypeOperation, UnauthorizedError } from 'fhir-works-on-aws-interface';
 import { SMARTHandler } from './smartHandler';
 import { SMARTConfig, ScopeRule } from './smartConfig';
-import { TokenIntrospectionStrategy } from './smartStrategy';
+import { UserInfoStrategy } from './smartStrategy';
 
 const allReadOperations: (TypeOperation | SystemOperation)[] = [
     'read',
@@ -87,7 +87,7 @@ const authZConfig: SMARTConfig = {
     expectedFhirUserClaimKey: 'fhirUser',
     fhirUserClaimRegex: /(\w+)\/(\w+)/g,
     authZUserInfoUrl: `${expectedIss}/userInfo`,
-    authStrategies: [new TokenIntrospectionStrategy(`${expectedIss}/userInfo`, 'fhirUser')],
+    authStrategies: [new UserInfoStrategy(`${expectedIss}/userInfo`, 'fhirUser')],
 };
 
 const mock = new MockAdapter(axios);

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -7,7 +7,6 @@ import MockAdapter from 'axios-mock-adapter';
 import { AuthorizationRequest, SystemOperation, TypeOperation, UnauthorizedError } from 'fhir-works-on-aws-interface';
 import { SMARTHandler } from './smartHandler';
 import { SMARTConfig, ScopeRule } from './smartConfig';
-import { UserInfoStrategy } from './smartStrategy';
 
 const allReadOperations: (TypeOperation | SystemOperation)[] = [
     'read',
@@ -87,7 +86,6 @@ const authZConfig: SMARTConfig = {
     expectedFhirUserClaimKey: 'fhirUser',
     fhirUserClaimRegex: /(\w+)\/(\w+)/g,
     authZUserInfoUrl: `${expectedIss}/userInfo`,
-    authStrategies: [new UserInfoStrategy(`${expectedIss}/userInfo`, 'fhirUser')],
 };
 
 const mock = new MockAdapter(axios);

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -64,7 +64,7 @@ export class SMARTHandler implements Authorization {
         const results = [];
         for (let i = 0; i < this.config.authStrategies.length; i += 1) {
             const strategy = this.config.authStrategies[i];
-            results.push(strategy.isTokenValid(request.accessToken));
+            results.push(strategy.validateToken(request.accessToken));
         }
         await Promise.all(results);
     }

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -89,7 +89,7 @@ export class SMARTHandler implements Authorization {
         await this.isAuthorized({ accessToken: request.accessToken, operation: request.operation });
     }
 
-    protected isScopeSufficient(
+    private isScopeSufficient(
         scopes: string[],
         operation: TypeOperation | SystemOperation,
         resourceType?: string,
@@ -129,7 +129,7 @@ export class SMARTHandler implements Authorization {
         return false;
     }
 
-    protected getValidOperation(scopeType: ScopeType, accessType: string) {
+    private getValidOperation(scopeType: ScopeType, accessType: string) {
         let validOperations: (TypeOperation | SystemOperation)[] = [];
         if (accessType === '*' || accessType === 'read') {
             validOperations = this.config.scopeRule[scopeType].read;

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -61,11 +61,9 @@ export class SMARTHandler implements Authorization {
         }
 
         // Verify token
-        const results = [];
-        for (let i = 0; i < this.config.authStrategies.length; i += 1) {
-            const strategy = this.config.authStrategies[i];
-            results.push(strategy.validateToken(request.accessToken));
-        }
+        const results = this.config.authStrategies.map(strategy => {
+            return strategy.validateToken(request.accessToken);
+        });
         await Promise.all(results);
     }
 

--- a/src/smartStrategy.ts
+++ b/src/smartStrategy.ts
@@ -10,7 +10,7 @@ export interface AuthStrategy {
     isTokenValid(accessToken: string): Promise<void>;
 }
 
-export class TokenIntrospectionStrategy implements AuthStrategy {
+export class UserInfoStrategy implements AuthStrategy {
     private readonly authZUserInfoUrl: string;
 
     private readonly expectedFhirUserClaimKey: string;

--- a/src/smartStrategy.ts
+++ b/src/smartStrategy.ts
@@ -4,16 +4,31 @@
  */
 
 export interface AuthStrategy {
+
     /**
-     * Validates access for a given access token, fhirUser claim, and all the userinfo
+     * Verifies the access_token contents
      * @param decodedAccessToken
-     * @param fhirUser
+     * @throws UnauthorizedError
+     */
+    verifyAccessToken(decodedAccessToken: { [k: string]: any }): Promise<void>;
+
+    /**
+     * Verifies the /userinfo contents (which mimics the id_token)
      * @param userinfo
      * @throws UnauthorizedError
      */
-    validateAccess(
-        decodedAccessToken: { [k: string]: any },
-        userinfo: { [k: string]: any },
-        fhirUser: string,
-    ): Promise<void>;
+    verifyUserInfo(userinfo: { [k: string]: any }): Promise<void>;
+
+    /**
+     * Verifies the fhirUser claim
+     * @param fhirUser
+     * @throws UnauthorizedError
+     */
+    verifyFhirUserClaim(fhirUser: string): Promise<void>;
+
+    /**
+     * Verifies and authorizes access to the ReadResponse
+     * @throws UnauthorizedError
+     */
+    authorizeReadResponse(): Promise<void>;
 }

--- a/src/smartStrategy.ts
+++ b/src/smartStrategy.ts
@@ -10,6 +10,10 @@ export interface AuthStrategy {
     isTokenValid(accessToken: string): Promise<void>;
 }
 
+/**
+ * This strategy uses the /userinfo endpoint to verify the `access_token` and get the `fhirUser` claim for further authorization.
+ * userinfo endpoint is OIDC compliant: https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
+ */
 export class UserInfoStrategy implements AuthStrategy {
     private readonly authZUserInfoUrl: string;
 

--- a/src/smartStrategy.ts
+++ b/src/smartStrategy.ts
@@ -7,7 +7,7 @@ export interface AuthStrategy {
      * @param accessToken
      * @throws UnauthorizedError
      */
-    isTokenValid(accessToken: string): Promise<void>;
+    validateToken(accessToken: string): Promise<void>;
 }
 
 /**
@@ -24,7 +24,7 @@ export class UserInfoStrategy implements AuthStrategy {
         this.expectedFhirUserClaimKey = expectedFhirUserClaimKey;
     }
 
-    async isTokenValid(accessToken: string): Promise<void> {
+    async validateToken(accessToken: string): Promise<void> {
         let response;
         try {
             response = await axios.post(

--- a/src/smartStrategy.ts
+++ b/src/smartStrategy.ts
@@ -1,0 +1,39 @@
+import axios from 'axios';
+import { UnauthorizedError } from 'fhir-works-on-aws-interface';
+
+export interface AuthStrategy {
+    /**
+     * Validates the JWT access_token
+     * @param accessToken
+     * @throws UnauthorizedError
+     */
+    isTokenValid(accessToken: string): Promise<void>;
+}
+
+export class TokenIntrospectionStrategy implements AuthStrategy {
+    private readonly authZUserInfoUrl: string;
+
+    private readonly expectedFhirUserClaimKey: string;
+
+    constructor(authZUserInfoUrl: string, expectedFhirUserClaimKey: string) {
+        this.authZUserInfoUrl = authZUserInfoUrl;
+        this.expectedFhirUserClaimKey = expectedFhirUserClaimKey;
+    }
+
+    async isTokenValid(accessToken: string): Promise<void> {
+        let response;
+        try {
+            response = await axios.post(
+                this.authZUserInfoUrl,
+                {},
+                { headers: { Authorization: `Bearer ${accessToken}` } },
+            );
+        } catch (e) {
+            console.error('Post to authZUserInfoUrl failed', e);
+        }
+        if (!response || !response.data[this.expectedFhirUserClaimKey]) {
+            console.error(`result from AuthZ did not have the '${this.expectedFhirUserClaimKey}' claim`);
+            throw new UnauthorizedError("Cannot determine requester's identity");
+        }
+    }
+}

--- a/src/smartStrategy.ts
+++ b/src/smartStrategy.ts
@@ -1,43 +1,19 @@
-import axios from 'axios';
-import { UnauthorizedError } from 'fhir-works-on-aws-interface';
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
 
 export interface AuthStrategy {
     /**
-     * Validates the JWT access_token
-     * @param accessToken
+     * Validates access for a given access token, fhirUser claim, and all the userinfo
+     * @param decodedAccessToken
+     * @param fhirUser
+     * @param userinfo
      * @throws UnauthorizedError
      */
-    validateToken(accessToken: string): Promise<void>;
-}
-
-/**
- * This strategy uses the /userinfo endpoint to verify the `access_token` and get the `fhirUser` claim for further authorization.
- * userinfo endpoint is OIDC compliant: https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
- */
-export class UserInfoStrategy implements AuthStrategy {
-    private readonly authZUserInfoUrl: string;
-
-    private readonly expectedFhirUserClaimKey: string;
-
-    constructor(authZUserInfoUrl: string, expectedFhirUserClaimKey: string) {
-        this.authZUserInfoUrl = authZUserInfoUrl;
-        this.expectedFhirUserClaimKey = expectedFhirUserClaimKey;
-    }
-
-    async validateToken(accessToken: string): Promise<void> {
-        let response;
-        try {
-            response = await axios.post(
-                this.authZUserInfoUrl,
-                {},
-                { headers: { Authorization: `Bearer ${accessToken}` } },
-            );
-        } catch (e) {
-            console.error('Post to authZUserInfoUrl failed', e);
-        }
-        if (!response || !response.data[this.expectedFhirUserClaimKey]) {
-            console.error(`result from AuthZ did not have the '${this.expectedFhirUserClaimKey}' claim`);
-            throw new UnauthorizedError("Cannot determine requester's identity");
-        }
-    }
+    validateAccess(
+        decodedAccessToken: { [k: string]: any },
+        userinfo: { [k: string]: any },
+        fhirUser: string,
+    ): Promise<void>;
 }


### PR DESCRIPTION
**Background:** 

The SMART-on-FHIR specification only governs the exchange of scopes between the SMARTApp and the authorization server and does not take a position on how an authorization server and resource server ought to coordinate authorization. The latter is left up to the implementer. 

The current implementation uses token introspection via the `/userinfo` url. However, The SMART-on-FHIR specification does not require the `fhirUser` claim to be present in the `access_token` or via the `/userinfo` endpoint on the authorization server. Therefore, other implementations of the authorization server (like Auth0) will not be able to comply with these expectations. 

This is a proposal for a more flexible strategy pattern that will allow implementers to design their own token validation and authorization strategies.

**Description of changes:**

This change refactors the `SMARTHandler.isAuthorized()` method such that the specific authorization strategy used to implement SMART-on-FHIR can be encapsulated in classes that implement the (new) `AuthStrategy` interface. This allows other implementations to define their own strategies and inject them into the authorization flow via the `SMARTConfig` object. 

Example config: 
```
const authZConfig: SMARTConfig = {
    version: 1.0,
    scopeKey: 'scp',
    scopeValueType: 'array',
    scopeRule,
    expectedAudValue: expectedAud,
    expectedIssValue: expectedIss,
    expectedFhirUserClaimKey: 'fhirUser',
    fhirUserClaimRegex: /(\w+)\/(\w+)/g,
    authZUserInfoUrl: `${expectedIss}/userInfo`,
    authStrategies: [new UserInfoStrategy(`${expectedIss}/userInfo`, 'fhirUser')],
};
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
