### PR TITLE
feat: implement new interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "axios": "^0.20.0",
-    "fhir-works-on-aws-interface": "^3.0.0-beta.1",
+    "fhir-works-on-aws-interface": "^3.0.0",
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint-fix": "eslint --fix . --ext .ts,.tsx",
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest --silent --passWithNoTests",
+    "test": "jest --silent",
     "test-coverage": "jest --coverage",
     "release": "yarn run build && yarn run lint && yarn run test",
     "clean": "rm -rf build/* node_modules/* dist/* .serverless/* .nyc_output/* lib/*",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "axios": "^0.20.0",
-    "fhir-works-on-aws-interface": "^3.0.0",
+    "fhir-works-on-aws-interface": "^4.0.0",
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {

--- a/src/regExpressions.test.ts
+++ b/src/regExpressions.test.ts
@@ -1,0 +1,136 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SMARTHandler } from './smartHandler';
+
+describe('CLINICAL_SCOPE_REGEX', () => {
+    const testCases = [
+        ['patient', 'Patient', 'read', true],
+        ['user', 'Patient', 'read', true],
+        ['system', 'Patient', 'read', true],
+        ['patient', 'Patient', 'write', true],
+        ['patient', 'Patient', '*', true],
+        ['patient', 'Observation', 'read', true],
+        ['patient', 'FakeResource', 'write', true],
+        ['patient', '*', 'write', true],
+        ['patient', 'uncapitalizedResource', 'write', false],
+        ['fake', 'Patient', 'write', false],
+        ['patient', 'Patient', 'fake', false],
+        ['patient', 'Patient1', '*', false],
+        ['', 'Patient', 'read', false],
+        ['patient', '', 'read', false],
+        ['patient', 'Patient', '', false],
+    ];
+    test.each(testCases)('CASE: %p/%p.%p; expect: %p', async (scopeType, scopeResourceType, accessType, isSuccess) => {
+        const expectedStr = `${scopeType}/${scopeResourceType}.${accessType}`;
+        const actualMatch = expectedStr.match(SMARTHandler.CLINICAL_SCOPE_REGEX);
+        if (isSuccess) {
+            expect(actualMatch).toBeTruthy();
+            expect(actualMatch!.groups).toBeTruthy();
+            expect(actualMatch!.groups!.scopeType).toEqual(scopeType);
+            expect(actualMatch!.groups!.scopeResourceType).toEqual(scopeResourceType);
+            expect(actualMatch!.groups!.accessType).toEqual(accessType);
+        } else {
+            expect(actualMatch).toBeFalsy();
+        }
+    });
+    const uniqueTestCases = [
+        ['patient.Patient/read'],
+        ['plain old wrong'],
+        ['patient/Patient.read patient/Patient.read'],
+        ['launch/patient'],
+        ['patient.Patient/read '],
+    ];
+    test.each(uniqueTestCases)('CASE: %p; expect: false', async scope => {
+        const actualMatch = scope.match(SMARTHandler.CLINICAL_SCOPE_REGEX);
+        expect(actualMatch).toBeFalsy();
+    });
+});
+describe('LAUNCH_SCOPE_REGEX', () => {
+    const testCases = [
+        ['launch', 'patient', true],
+        ['launch', 'encounter', true],
+        ['Launch', 'encounter', false],
+        ['launch', 'Encounter', false],
+        ['launch1', 'encounter', false],
+        ['launch', 'encounter1', false],
+        ['launch', '', false],
+        ['', 'encounter', false],
+    ];
+    test.each(testCases)('CASE: %p/%p; expect: %p', async (scopeType, launchType, isSuccess) => {
+        const expectedStr = `${scopeType}/${launchType}`;
+        const actualMatch = expectedStr.match(SMARTHandler.LAUNCH_SCOPE_REGEX);
+        if (isSuccess) {
+            expect(actualMatch).toBeTruthy();
+            expect(actualMatch!.groups).toBeTruthy();
+            expect(actualMatch!.groups!.scopeType).toEqual(scopeType);
+            expect(actualMatch!.groups!.launchType).toEqual(launchType);
+        } else {
+            expect(actualMatch).toBeFalsy();
+        }
+    });
+    const uniqueTestCases = [
+        ['patient/Patient.read'],
+        ['launch.encounter'],
+        ['plain old wrong'],
+        ['launch/encounter launch/encounter'],
+        ['launch/encounter '],
+    ];
+    test.each(uniqueTestCases)('CASE: %p; expect: false', async scope => {
+        const actualMatch = scope.match(SMARTHandler.LAUNCH_SCOPE_REGEX);
+        expect(actualMatch).toBeFalsy();
+    });
+});
+describe('FHIR_USER_REGEX', () => {
+    const testCases = [
+        ['https://fhir.server.com/dev/', 'Patient', 'id', true],
+        ['http://fhir.server.com/dev/', 'Patient', 'id', true],
+        ['http://fhir.server.com/dev-.:/%/$/2/', 'Patient', 'id', true],
+        ['http://localhost/projectname/', 'Patient', 'id', true],
+        ['http://127.0.0.1/project_name/', 'Patient', 'id', true],
+        ['https://127.0.0.1:8080/project_name/', 'Patient', 'id', true],
+        ['https://fhir.server.com/dev/', 'Practitioner', 'id', true],
+        ['https://fhir.server.com/dev/', 'RelatedPerson', 'id', true],
+        ['https://fhir.server.com/dev/', 'Person', 'id', true],
+        ['https://fhir.server.com/dev/', 'Patient', 'idID1234-123.aBc', true],
+        ['', 'Patient', 'id', false],
+        ['https://fhir.server.com/dev/', '', 'id', false],
+        ['https://fhir.server.com/dev/', 'Patient', '', false],
+        ['fhir.server.com/dev/', 'Patient', 'id', false],
+        ['https://fhir.server.com/dev', 'Patient', 'id', false],
+        ['127.0.0.1/project_name', 'Patient', 'id', false],
+        ['https://fhir.server.com/dev/', 'Observation', 'id', false],
+        ['https://fhir.server.com/dev/', 'Patient', 'i_d', false],
+        ['https://fhir.server.com/dev/', 'Patient', 'i#d', false],
+        ['https://fhir.server.com/dev/', 'Patient', 'id ', false],
+        [' https://fhir.server.com/dev/', 'Patient', 'id', false],
+    ];
+    test.each(testCases)('CASE: %p%p/%p; expect: %p', async (hostname, resourceType, id, isSuccess) => {
+        for (let i = 0; i < testCases.length; i += 1) {
+            const expectedStr = `${hostname}${resourceType}/${id}`;
+            const actualMatch = expectedStr.match(SMARTHandler.FHIR_USER_REGEX);
+            if (isSuccess) {
+                expect(actualMatch).toBeTruthy();
+                expect(actualMatch!.groups).toBeTruthy();
+                expect(actualMatch!.groups!.hostname).toEqual(hostname);
+                expect(actualMatch!.groups!.resourceType).toEqual(resourceType);
+                expect(actualMatch!.groups!.id).toEqual(id);
+            } else {
+                expect(actualMatch).toBeFalsy();
+            }
+        }
+    });
+    const uniqueTestCases = [
+        ['patient/Patient.read'],
+        ['launch/encounter'],
+        ['just-an-id-1234'],
+        ['Patient'],
+        ['https://fhir.server.com/dev/'],
+    ];
+    test.each(uniqueTestCases)('CASE: %p; expect: false', async scope => {
+        const actualMatch = scope.match(SMARTHandler.FHIR_USER_REGEX);
+        expect(actualMatch).toBeFalsy();
+    });
+});

--- a/src/smartConfig.ts
+++ b/src/smartConfig.ts
@@ -27,7 +27,7 @@ export interface SMARTConfig {
      */
     expectedIssValue: string;
     /**
-     * Per SMART spec this is the 'iss' key found in the access_token
+     * Name of the claim found in the access_token that represents the requestors FHIR Id
      */
     expectedFhirUserClaimKey: 'fhirUser' | 'profile';
     /**
@@ -37,7 +37,7 @@ export interface SMARTConfig {
     /**
      * OAuth2 standard URL used to verify the access_token and get all user claims
      */
-    authZUserInfoUrl: string;
+    userInfoEndpoint: string;
 }
 
 export type AccessModifier = 'read' | 'write';

--- a/src/smartConfig.ts
+++ b/src/smartConfig.ts
@@ -39,6 +39,7 @@ export interface SMARTConfig {
 export type AccessModifier = 'read' | 'write';
 export type ScopeType = 'patient' | 'user' | 'system';
 export type LaunchType = 'patient' | 'encounter';
+export type IdentityType = 'Patient' | 'Practitioner' | 'Person ' | 'RelatedPerson';
 
 // Determines what each scope has access to
 export type ScopeRule = {

--- a/src/smartConfig.ts
+++ b/src/smartConfig.ts
@@ -29,11 +29,7 @@ export interface SMARTConfig {
     /**
      * Name of the claim found in the access_token that represents the requestors FHIR Id
      */
-    expectedFhirUserClaimKey: 'fhirUser' | 'profile';
-    /**
-     * This regex representing what the `fhirUser` claim will become
-     */
-    fhirUserClaimRegex: RegExp;
+    fhirUserClaimKey: 'fhirUser' | 'profile';
     /**
      * OAuth2 standard URL used to verify the access_token and get all user claims
      */

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -595,7 +595,27 @@ describe('authorizeAndFilterReadResponse', () => {
             {},
         ],
         [
-            'READ: external FHIR Server Practitioner able to read Encounter',
+            'READ: Practitioner able to read Encounter',
+            {
+                userIdentity: validPractitionerIdentity,
+                operation: 'read',
+                readResponse: validPatientEncounter,
+            },
+            true,
+            validPatientEncounter,
+        ],
+        [
+            'READ: Practitioner able to read unrelated Observation',
+            {
+                userIdentity: validPractitionerIdentity,
+                operation: 'read',
+                readResponse: validPatientObservation,
+            },
+            true,
+            validPatientObservation,
+        ],
+        [
+            'READ: external Practitioner able to read Encounter',
             {
                 userIdentity: validExternalPractitionerIdentity,
                 operation: 'read',
@@ -605,7 +625,7 @@ describe('authorizeAndFilterReadResponse', () => {
             validPatientEncounter,
         ],
         [
-            'READ: external FHIR Server Practitioner unable to read Observation',
+            'READ: external Practitioner unable to read Observation',
             {
                 userIdentity: validExternalPractitionerIdentity,
                 operation: 'read',
@@ -655,7 +675,7 @@ describe('authorizeAndFilterReadResponse', () => {
             emptySearchResult,
         ],
         [
-            'SEARCH: Practitioner able to search and filtered to just the encounter',
+            'SEARCH: external Practitioner able to search and filtered to just the encounter',
             {
                 userIdentity: validExternalPractitionerIdentity,
                 operation: 'search-type',
@@ -663,6 +683,16 @@ describe('authorizeAndFilterReadResponse', () => {
             },
             true,
             { ...emptySearchResult, entry: [createEntry(validPatientEncounter)] },
+        ],
+        [
+            'SEARCH: Practitioner able to search and get ALL results',
+            {
+                userIdentity: validPractitionerIdentity,
+                operation: 'search-type',
+                readResponse: searchAllEntitiesMatch,
+            },
+            true,
+            searchAllEntitiesMatch,
         ],
     ];
 

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -6,6 +6,7 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import {
     VerifyAccessTokenRequest,
+    ReadResponseAuthorizedRequest,
     SystemOperation,
     TypeOperation,
     UnauthorizedError,
@@ -88,10 +89,13 @@ const authZConfig: SMARTConfig = {
     scopeRule,
     expectedAudValue: expectedAud,
     expectedIssValue: expectedIss,
-    expectedFhirUserClaimKey: 'fhirUser',
-    fhirUserClaimRegex: /(\w+)\/(\w+)/g,
+    fhirUserClaimKey: 'fhirUser',
     userInfoEndpoint: `${expectedIss}/userInfo`,
 };
+const apiUrl = 'https://fhir.server.com/dev/';
+const patientId = 'Patient/1234';
+const validPatientIdentity = { [authZConfig.fhirUserClaimKey]: `${apiUrl}${patientId}` };
+const validExternalPractitionerIdentity = { [authZConfig.fhirUserClaimKey]: `${apiUrl}test/Practitioner/1234` };
 
 const mock = new MockAdapter(axios);
 beforeEach(() => {
@@ -104,61 +108,86 @@ describe('constructor', () => {
     test('ERROR: Attempt to create a handler to support a new config version', async () => {
         expect(() => {
             // eslint-disable-next-line no-new
-            new SMARTHandler({
-                ...authZConfig,
-                version: 2.0,
-            });
+            new SMARTHandler(
+                {
+                    ...authZConfig,
+                    version: 2.0,
+                },
+                apiUrl,
+            );
         }).toThrow(new Error('Authorization configuration version does not match handler version'));
     });
 });
 
-const arrayScopesCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
-    ['aud_failure', { accessToken: audStringWrongAccess, operation: 'create', resourceType: 'Patient' }, false],
-    ['iss_failure', { accessToken: issWrongAccess, operation: 'create', resourceType: 'Patient' }, false],
-    ['no_fhir_scopes', { accessToken: noFHIRScopesAccess, operation: 'create', resourceType: 'Patient' }, false],
-    ['launch_scope', { accessToken: launchAccess, operation: 'create', resourceType: 'Patient' }, false],
-    ['launch/patient', { accessToken: launchPatientAccess, operation: 'search-system' }, true],
-    [
-        'launch/encounter',
-        { accessToken: launchEncounterAccess, operation: 'read', resourceType: 'Patient', id: '123' },
-        true,
-    ],
-    ['manyRead_Write', { accessToken: manyReadAccess, operation: 'update', resourceType: 'Patient', id: '12' }, false],
-    [
-        'manyRead_Read',
-        { accessToken: manyReadAccess, operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
-        true,
-    ],
-    ['manyRead_search', { accessToken: manyReadAccess, operation: 'search-type', resourceType: 'Observation' }, true],
-    ['manyWrite_Read', { accessToken: manyWriteAccess, operation: 'read', resourceType: 'Patient', id: '12' }, false],
-    [
-        'manyWrite_Write_transaction. patient scope does not have access to transaction',
-        { accessToken: manyWriteAccess, operation: 'transaction' },
-        false,
-    ],
-    [
-        'manyRead_withSpaceScope',
-        { accessToken: manyReadAccessScopeSpaces, operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
-        false,
-    ],
-    ['manyWrite_Write_create', { accessToken: manyWriteAccess, operation: 'create', resourceType: 'Patient' }, true],
-    ['sys_read', { accessToken: allSysAccess, operation: 'read', resourceType: 'Patient', id: '12' }, true],
-    ['sys_transaction', { accessToken: allSysAccess, operation: 'transaction' }, true],
-    ['sys_history', { accessToken: allSysAccess, operation: 'history-system' }, true],
-    ['sys_fakeType', { accessToken: allSysAccess, operation: 'create', resourceType: 'Fake' }, true],
-];
 describe('verifyAccessToken; scopes are in an array', () => {
-    const authZHandler: SMARTHandler = new SMARTHandler(authZConfig);
+    const arrayScopesCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
+        ['aud_failure', { accessToken: audStringWrongAccess, operation: 'create', resourceType: 'Patient' }, false],
+        ['iss_failure', { accessToken: issWrongAccess, operation: 'create', resourceType: 'Patient' }, false],
+        ['no_fhir_scopes', { accessToken: noFHIRScopesAccess, operation: 'create', resourceType: 'Patient' }, false],
+        ['launch_scope', { accessToken: launchAccess, operation: 'create', resourceType: 'Patient' }, false],
+        ['launch/patient', { accessToken: launchPatientAccess, operation: 'search-system' }, true],
+        [
+            'launch/encounter',
+            { accessToken: launchEncounterAccess, operation: 'read', resourceType: 'Patient', id: '123' },
+            true,
+        ],
+        [
+            'manyRead_Write',
+            { accessToken: manyReadAccess, operation: 'update', resourceType: 'Patient', id: '12' },
+            false,
+        ],
+        [
+            'manyRead_Read',
+            { accessToken: manyReadAccess, operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
+            true,
+        ],
+        [
+            'manyRead_search',
+            { accessToken: manyReadAccess, operation: 'search-type', resourceType: 'Observation' },
+            true,
+        ],
+        [
+            'manyWrite_Read',
+            { accessToken: manyWriteAccess, operation: 'read', resourceType: 'Patient', id: '12' },
+            false,
+        ],
+        [
+            'manyWrite_Write_transaction. patient scope does not have access to transaction',
+            { accessToken: manyWriteAccess, operation: 'transaction' },
+            false,
+        ],
+        [
+            'manyRead_withSpaceScope',
+            {
+                accessToken: manyReadAccessScopeSpaces,
+                operation: 'vread',
+                resourceType: 'Observation',
+                id: '1',
+                vid: '1',
+            },
+            false,
+        ],
+        [
+            'manyWrite_Write_create',
+            { accessToken: manyWriteAccess, operation: 'create', resourceType: 'Patient' },
+            true,
+        ],
+        ['sys_read', { accessToken: allSysAccess, operation: 'read', resourceType: 'Patient', id: '12' }, true],
+        ['sys_transaction', { accessToken: allSysAccess, operation: 'transaction' }, true],
+        ['sys_history', { accessToken: allSysAccess, operation: 'history-system' }, true],
+        ['sys_fakeType', { accessToken: allSysAccess, operation: 'create', resourceType: 'Fake' }, true],
+    ];
+
+    const authZHandler: SMARTHandler = new SMARTHandler(authZConfig, apiUrl);
     test.each(arrayScopesCases)('CASE: %p', async (_firstArg, request, isValid) => {
-        const userIdentity = { fhirUser: '123' };
-        mock.onGet(authZConfig.userInfoEndpoint).reply(200, userIdentity);
+        mock.onGet(authZConfig.userInfoEndpoint).reply(200, validPatientIdentity);
         if (!isValid) {
             await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).rejects.toThrowError(
                 UnauthorizedError,
             );
         } else {
             await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toEqual(
-                userIdentity,
+                validPatientIdentity,
             );
         }
     });
@@ -169,117 +198,157 @@ describe('verifyAccessToken; metadata and well-known route', () => {
         ['metadata', { accessToken: '', operation: 'read', resourceType: 'metadata' }],
         ['well-known', { accessToken: '', operation: 'read', resourceType: '.well-known' }],
     ];
-    const authZHandler: SMARTHandler = new SMARTHandler(authZConfig);
+    const authZHandler: SMARTHandler = new SMARTHandler(authZConfig, apiUrl);
     test.each(cases)('CASE: %p', async (_firstArg, request) => {
         expect(authZHandler.verifyAccessToken(request as VerifyAccessTokenRequest)).resolves.toEqual({});
     });
 });
 
-const spaceScopesCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
-    [
-        'manyRead_Write',
-        { accessToken: manyReadAccessScopeSpaces, operation: 'update', resourceType: 'Patient', id: '12' },
-        false,
-    ],
-    [
-        'manyRead_Read',
-        { accessToken: manyReadAccessScopeSpaces, operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
-        true,
-    ],
-    [
-        'manyRead_search',
-        { accessToken: manyReadAccessScopeSpaces, operation: 'search-type', resourceType: 'Observation' },
-        true,
-    ],
-    [
-        'manyRead_launchScopeOnly',
-        { accessToken: manyReadAccessScopeSpacesJustLaunch, operation: 'read', resourceType: 'Observation', id: '1' },
-        true,
-    ],
-    [
-        'manyRead_withArrayScope',
-        { accessToken: manyReadAccess, operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
-        false,
-    ],
-];
 describe('verifyAccessToken; scopes are space delimited', () => {
-    const authZHandler: SMARTHandler = new SMARTHandler({
-        ...authZConfig,
-        scopeValueType: 'space',
-    });
-    const userIdentity = { fhirUser: '123' };
+    const spaceScopesCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
+        [
+            'manyRead_Write',
+            { accessToken: manyReadAccessScopeSpaces, operation: 'update', resourceType: 'Patient', id: '12' },
+            false,
+        ],
+        [
+            'manyRead_Read',
+            {
+                accessToken: manyReadAccessScopeSpaces,
+                operation: 'vread',
+                resourceType: 'Observation',
+                id: '1',
+                vid: '1',
+            },
+            true,
+        ],
+        [
+            'manyRead_search',
+            { accessToken: manyReadAccessScopeSpaces, operation: 'search-type', resourceType: 'Observation' },
+            true,
+        ],
+        [
+            'manyRead_launchScopeOnly',
+            {
+                accessToken: manyReadAccessScopeSpacesJustLaunch,
+                operation: 'read',
+                resourceType: 'Observation',
+                id: '1',
+            },
+            true,
+        ],
+        [
+            'manyRead_withArrayScope',
+            { accessToken: manyReadAccess, operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
+            false,
+        ],
+    ];
+
+    const authZHandler: SMARTHandler = new SMARTHandler(
+        {
+            ...authZConfig,
+            scopeValueType: 'space',
+        },
+        apiUrl,
+    );
 
     test.each(spaceScopesCases)('CASE: %p', async (_firstArg, request, isValid) => {
-        mock.onGet(authZConfig.userInfoEndpoint).reply(200, { fhirUser: '123' });
+        mock.onGet(authZConfig.userInfoEndpoint).reply(200, validPatientIdentity);
         if (!isValid) {
             await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).rejects.toThrowError(
                 UnauthorizedError,
             );
         } else {
             await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toEqual(
-                userIdentity,
+                validPatientIdentity,
             );
         }
     });
 });
 
-const arrayAUDCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
-    [
-        'aud_not_in_array',
-        { accessToken: audArrayWrongAccess, operation: 'search-type', resourceType: 'Observation' },
-        false,
-    ],
-    ['aud_in_array', { accessToken: audArrayValidAccess, operation: 'search-type', resourceType: 'Observation' }, true],
-];
 describe('verifyAccessToken; aud is in an array', () => {
-    const authZHandler: SMARTHandler = new SMARTHandler({
-        ...authZConfig,
-        scopeValueType: 'array',
-    });
-    const userIdentity = { fhirUser: '123' };
+    const arrayAUDCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
+        [
+            'aud_not_in_array',
+            { accessToken: audArrayWrongAccess, operation: 'search-type', resourceType: 'Observation' },
+            false,
+        ],
+        [
+            'aud_in_array',
+            { accessToken: audArrayValidAccess, operation: 'search-type', resourceType: 'Observation' },
+            true,
+        ],
+    ];
+
+    const authZHandler: SMARTHandler = new SMARTHandler(
+        {
+            ...authZConfig,
+            scopeValueType: 'array',
+        },
+        apiUrl,
+    );
 
     test.each(arrayAUDCases)('CASE: %p', async (_firstArg, request, isValid) => {
-        mock.onGet(authZConfig.userInfoEndpoint).reply(200, { fhirUser: '123' });
+        mock.onGet(authZConfig.userInfoEndpoint).reply(200, validPatientIdentity);
         if (!isValid) {
             await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).rejects.toThrowError(
                 UnauthorizedError,
             );
         } else {
             await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toEqual(
-                userIdentity,
+                validPatientIdentity,
             );
         }
     });
 });
 
-const apiCases: (string | boolean | VerifyAccessTokenRequest | number | any)[][] = [
-    [
-        '200; sucess',
-        { accessToken: manyReadAccess, operation: 'search-type', resourceType: 'Observation' },
-        200,
-        { [authZConfig.expectedFhirUserClaimKey]: '1234' },
-        true,
-    ],
-    [
-        '202; success',
-        { accessToken: manyWriteAccess, operation: 'create', resourceType: 'Patient' },
-        202,
-        { [authZConfig.expectedFhirUserClaimKey]: '1234' },
-        true,
-    ],
-    ['4XX; failure', { accessToken: manyWriteAccess, operation: 'create', resourceType: 'Patient' }, 403, {}, false],
-    ['5XX; failure', { accessToken: manyWriteAccess, operation: 'create', resourceType: 'Patient' }, 500, {}, false],
-    [
-        'Cannot find claim',
-        { accessToken: allSysAccess, operation: 'read', resourceType: 'Patient', id: '12' },
-        200,
-        { stuff: '1234' },
-        false,
-    ],
-];
-
 describe("verifyAccessToken; AuthZ's userInfo interactions", () => {
-    const authZHandler: SMARTHandler = new SMARTHandler(authZConfig);
+    const apiCases: (string | boolean | VerifyAccessTokenRequest | number | any)[][] = [
+        [
+            '200; sucess',
+            { accessToken: manyReadAccess, operation: 'search-type', resourceType: 'Observation' },
+            200,
+            validPatientIdentity,
+            true,
+        ],
+        [
+            '202; success',
+            { accessToken: manyWriteAccess, operation: 'create', resourceType: 'Patient' },
+            202,
+            validPatientIdentity,
+            true,
+        ],
+        [
+            '4XX; failure',
+            { accessToken: manyWriteAccess, operation: 'create', resourceType: 'Patient' },
+            403,
+            {},
+            false,
+        ],
+        [
+            '5XX; failure',
+            { accessToken: manyWriteAccess, operation: 'create', resourceType: 'Patient' },
+            500,
+            {},
+            false,
+        ],
+        [
+            'Cannot find claim',
+            { accessToken: allSysAccess, operation: 'read', resourceType: 'Patient', id: '12' },
+            200,
+            { stuff: '1234' },
+            false,
+        ],
+        [
+            'Claim regex does not match',
+            { accessToken: allSysAccess, operation: 'read', resourceType: 'Patient', id: '12' },
+            200,
+            { [authZConfig.fhirUserClaimKey]: '1234' },
+            false,
+        ],
+    ];
+
+    const authZHandler: SMARTHandler = new SMARTHandler(authZConfig, apiUrl);
     test.each(apiCases)('CASE: %p', async (_firstArg, request, authRespCode, authRespBody, isValid) => {
         mock.onGet(authZConfig.userInfoEndpoint).reply(<number>authRespCode, authRespBody);
         if (!isValid) {
@@ -297,5 +366,313 @@ describe("verifyAccessToken; AuthZ's userInfo interactions", () => {
         await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>apiCases[0][1])).rejects.toThrowError(
             UnauthorizedError,
         );
+    });
+});
+
+function createEntry(resource: any, searchMode = 'match') {
+    return {
+        fullUrl: `http://url.org/${resource.resourceType}/${resource.id}`,
+        resource,
+        search: {
+            mode: searchMode,
+        },
+    };
+}
+describe('authorizeAndFilterReadResponse', () => {
+    const validPatient = {
+        resourceType: 'Patient',
+        id: '1234',
+        meta: {
+            versionId: '1',
+            lastUpdated: '2020-06-28T12:03:29.421+00:00',
+        },
+        name: [
+            {
+                given: ['JONNY'],
+            },
+        ],
+        gender: 'male',
+        birthDate: '1972-10-13',
+        address: [
+            {
+                city: 'Ruppertshofen',
+            },
+        ],
+    };
+    const validPatientObservation = {
+        resourceType: 'Observation',
+        id: '1274045',
+        meta: {
+            versionId: '1',
+            lastUpdated: '2020-06-28T12:55:47.134+00:00',
+        },
+        status: 'final',
+        code: {
+            coding: [
+                {
+                    system: 'http://loinc.org',
+                    code: '15074-8',
+                    display: 'Glucose [Moles/volume] in Blood',
+                },
+            ],
+        },
+        subject: {
+            reference: validPatientIdentity[authZConfig.fhirUserClaimKey],
+            display: 'JONNY',
+        },
+        effectivePeriod: {
+            start: '2013-04-02T09:30:10+01:00',
+        },
+        issued: '2013-04-03T15:30:10+01:00',
+        valueQuantity: {
+            value: 6.3,
+            unit: 'mmol/l',
+            system: 'http://unitsofmeasure.org',
+            code: 'mmol/L',
+        },
+        interpretation: [
+            {
+                coding: [
+                    {
+                        system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation',
+                        code: 'H',
+                        display: 'High',
+                    },
+                ],
+            },
+        ],
+        referenceRange: [
+            {
+                low: {
+                    value: 3.1,
+                    unit: 'mmol/l',
+                    system: 'http://unitsofmeasure.org',
+                    code: 'mmol/L',
+                },
+                high: {
+                    value: 6.2,
+                    unit: 'mmol/l',
+                    system: 'http://unitsofmeasure.org',
+                    code: 'mmol/L',
+                },
+            },
+        ],
+    };
+    const validPatientEncounter = {
+        resourceType: 'Encounter',
+        id: '1339909',
+        meta: {
+            versionId: '1',
+            lastUpdated: '2019-02-06T19:32:37.166+00:00',
+        },
+        status: 'finished',
+        class: {
+            code: 'WELLNESS',
+        },
+        type: [
+            {
+                coding: [
+                    {
+                        system: 'http://snomed.info/sct',
+                        code: '185349003',
+                        display: 'Encounter for check up (procedure)',
+                    },
+                ],
+                text: 'Encounter for check up (procedure)',
+            },
+        ],
+        subject: {
+            reference: patientId,
+        },
+        participant: [
+            {
+                individual: {
+                    reference: validExternalPractitionerIdentity[authZConfig.fhirUserClaimKey],
+                },
+            },
+        ],
+        period: {
+            start: '2011-12-22T21:49:35-05:00',
+            end: '2011-12-22T22:19:35-05:00',
+        },
+        serviceProvider: {
+            reference: 'Organization/1339537',
+        },
+    };
+    const emptySearchResult = {
+        resourceType: 'Bundle',
+        id: '0694266b-9415-4a69-a6f1-43be974c2c46',
+        meta: {
+            lastUpdated: '2020-11-20T11:10:48.034+00:00',
+        },
+        type: 'searchset',
+        link: [
+            {
+                relation: 'self',
+                url: 'url.self',
+            },
+            {
+                relation: 'next',
+                url: 'url.next',
+            },
+        ],
+        entry: [],
+    };
+    const searchAllEntitiesMatch = {
+        ...emptySearchResult,
+        entry: [createEntry(validPatient), createEntry(validPatientObservation), createEntry(validPatientEncounter)],
+    };
+
+    const searchSomeEntitiesMatch = {
+        ...emptySearchResult,
+        entry: [
+            createEntry(validPatient),
+            createEntry(validPatientObservation),
+            createEntry({ ...validPatient, id: 'not-yours' }),
+            createEntry({ ...validPatientObservation, subject: 'not-you' }),
+            createEntry(validPatientEncounter),
+        ],
+    };
+    const searchNoEntitiesMatch = {
+        ...emptySearchResult,
+        entry: [
+            createEntry({ ...validPatient, id: 'not-yours' }),
+            createEntry({ ...validPatientObservation, subject: 'not-you' }),
+        ],
+    };
+    const cases: (string | ReadResponseAuthorizedRequest | boolean | any)[][] = [
+        [
+            'READ: Patient able to read own record',
+            {
+                userIdentity: validPatientIdentity,
+                operation: 'read',
+                readResponse: validPatient,
+            },
+            true,
+            validPatient,
+        ],
+        [
+            'READ: Patient able to vread own Observation (uses absolute url)',
+            {
+                userIdentity: validPatientIdentity,
+                operation: 'vread',
+                readResponse: validPatientObservation,
+            },
+            true,
+            validPatientObservation,
+        ],
+        [
+            'READ: Patient able to vread own Encounter (uses short-reference)',
+            {
+                userIdentity: validPatientIdentity,
+                operation: 'read',
+                readResponse: validPatientEncounter,
+            },
+            true,
+            validPatientEncounter,
+        ],
+        [
+            'READ: Patient unable to vread non-owned Patient record',
+            {
+                userIdentity: validPatientIdentity,
+                operation: 'vread',
+                readResponse: { ...validPatient, id: 'not-yours' },
+            },
+            false,
+            {},
+        ],
+        [
+            'READ: Patient unable to read non-direct Observation',
+            {
+                userIdentity: validPatientIdentity,
+                operation: 'read',
+                readResponse: { ...validPatientObservation, subject: 'not-you' },
+            },
+            false,
+            {},
+        ],
+        [
+            'READ: external FHIR Server Practitioner able to read Encounter',
+            {
+                userIdentity: validExternalPractitionerIdentity,
+                operation: 'read',
+                readResponse: validPatientEncounter,
+            },
+            true,
+            validPatientEncounter,
+        ],
+        [
+            'READ: external FHIR Server Practitioner unable to read Observation',
+            {
+                userIdentity: validExternalPractitionerIdentity,
+                operation: 'read',
+                readResponse: validPatientObservation,
+            },
+            false,
+            {},
+        ],
+        [
+            'SEARCH: Patient able to search for empty result',
+            {
+                userIdentity: validPatientIdentity,
+                operation: 'search-system',
+                readResponse: emptySearchResult,
+            },
+            true,
+            emptySearchResult,
+        ],
+        [
+            'SEARCH: Patient able to search for own Observation & Patient record',
+            {
+                userIdentity: validPatientIdentity,
+                operation: 'search-type',
+                readResponse: searchAllEntitiesMatch,
+            },
+            true,
+            searchAllEntitiesMatch,
+        ],
+        [
+            "SEARCH: Patient's history results are filtered to only contain valid entries",
+            {
+                userIdentity: validPatientIdentity,
+                operation: 'history-type',
+                readResponse: searchSomeEntitiesMatch,
+            },
+            true,
+            searchAllEntitiesMatch,
+        ],
+        [
+            "SEARCH: Patient's history results are all filtered out",
+            {
+                userIdentity: validPatientIdentity,
+                operation: 'history-system',
+                readResponse: searchNoEntitiesMatch,
+            },
+            true,
+            emptySearchResult,
+        ],
+        [
+            'SEARCH: Practitioner able to search and filtered to just the encounter',
+            {
+                userIdentity: validExternalPractitionerIdentity,
+                operation: 'search-type',
+                readResponse: searchAllEntitiesMatch,
+            },
+            true,
+            { ...emptySearchResult, entry: [createEntry(validPatientEncounter)] },
+        ],
+    ];
+
+    const authZHandler: SMARTHandler = new SMARTHandler(authZConfig, apiUrl);
+    test.each(cases)('CASE: %p', async (_firstArg, request, isValid, respBody) => {
+        if (!isValid) {
+            await expect(
+                authZHandler.authorizeAndFilterReadResponse(<ReadResponseAuthorizedRequest>request),
+            ).rejects.toThrowError(UnauthorizedError);
+        } else {
+            await expect(
+                authZHandler.authorizeAndFilterReadResponse(<ReadResponseAuthorizedRequest>request),
+            ).resolves.toEqual(respBody);
+        }
     });
 });

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -164,6 +164,17 @@ describe('verifyAccessToken; scopes are in an array', () => {
     });
 });
 
+describe('verifyAccessToken; metadata and well-known route', () => {
+    const cases = [
+        ['metadata', { accessToken: '', operation: 'read', resourceType: 'metadata' }],
+        ['well-known', { accessToken: '', operation: 'read', resourceType: '.well-known' }],
+    ];
+    const authZHandler: SMARTHandler = new SMARTHandler(authZConfig);
+    test.each(cases)('CASE: %p', async (_firstArg, request) => {
+        expect(authZHandler.verifyAccessToken(request as VerifyAccessTokenRequest)).resolves.toEqual({});
+    });
+});
+
 const spaceScopesCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
     [
         'manyRead_Write',
@@ -266,6 +277,7 @@ const apiCases: (string | boolean | VerifyAccessTokenRequest | number | any)[][]
         false,
     ],
 ];
+
 describe("verifyAccessToken; AuthZ's userInfo interactions", () => {
     const authZHandler: SMARTHandler = new SMARTHandler(authZConfig);
     test.each(apiCases)('CASE: %p', async (_firstArg, request, authRespCode, authRespBody, isValid) => {

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -161,6 +161,9 @@ export class SMARTHandler implements Authorization {
             // If requester is not from this FHIR Server they must be a fully qualified reference
             return jsonStr.includes(`"reference":"${fhirUser.hostname}${fhirUser.resourceType}/${fhirUser.id}"`);
         }
+        if (fhirUser.resourceType === 'Practitioner') {
+            return true;
+        }
         if (fhirUser.resourceType === resource.resourceType) {
             // Attempting to look up its own record
             return fhirUser.id === resource.id || this.isLocalUserInJsonAsReference(jsonStr, fhirUser);
@@ -224,8 +227,7 @@ export class SMARTHandler implements Authorization {
                         validOperations = this.getValidOperationsForScope(<ScopeType>scopeType, accessType);
                     }
                 }
-                const isAuthorized = validOperations.includes(operation);
-                if (isAuthorized) return true;
+                if (validOperations.includes(operation)) return true;
             }
         }
         return false;

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -126,7 +126,6 @@ export class SMARTHandler implements Authorization {
         return R4_PATIENT_COMPARTMENT_RESOURCES;
     }
 
-    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
     async authorizeAndFilterReadResponse(request: ReadResponseAuthorizedRequest): Promise<any> {
         const fhirUser = this.getFhirUser(request.userIdentity);
         const { operation, readResponse } = request;
@@ -143,7 +142,6 @@ export class SMARTHandler implements Authorization {
         return readResponse;
     }
 
-    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
     async isWriteRequestAuthorized(request: WriteRequestAuthorizedRequest): Promise<void> {
         const fhirUser = this.getFhirUser(request.userIdentity);
         if (fhirUser.hostname !== this.apiUrl || !this.typesWithWriteAccess.includes(fhirUser.resourceType)) {
@@ -151,7 +149,6 @@ export class SMARTHandler implements Authorization {
         }
     }
 
-    // eslint-disable-next-line class-methods-use-this
     private authorizeResource(
         fhirUser: { hostname: string; resourceType: IdentityType; id: string },
         resource: any,
@@ -182,7 +179,6 @@ export class SMARTHandler implements Authorization {
         );
     }
 
-    // eslint-disable-next-line class-methods-use-this
     private getFhirUser(userIdentity: KeyValueMap): { hostname: string; resourceType: IdentityType; id: string } {
         const { fhirUserClaimKey } = this.config;
         const fhirUserValue = userIdentity[fhirUserClaimKey];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,10 +1745,10 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fhir-works-on-aws-interface@^3.0.0-beta.1:
-  version "3.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-3.0.0-beta.1.tgz#7f37cbbad35c28242a9043b6653f1e1114cf112e"
-  integrity sha512-awbYzcmk8RfXza0gkzTfb1+YXZIxTF8E2T0gPjyoJneiriydIHlZuwzJyiNU/i6vOI2w1WQsholUivU8rjB5Rw==
+fhir-works-on-aws-interface@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-3.0.0.tgz#e4b5762755108169ef4f5b1ec92fafce8ca66da3"
+  integrity sha512-SFzwvu91seWKJCj8Qd6g/Y75eKnJ+y5CPY40ykHiylgN1XxbIy/E/zDkoo2tpjdmomVBcyJAN96/LxGXG9NfJw==
 
 figures@^3.0.0:
   version "3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,10 +1745,10 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fhir-works-on-aws-interface@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-3.0.0.tgz#e4b5762755108169ef4f5b1ec92fafce8ca66da3"
-  integrity sha512-SFzwvu91seWKJCj8Qd6g/Y75eKnJ+y5CPY40ykHiylgN1XxbIy/E/zDkoo2tpjdmomVBcyJAN96/LxGXG9NfJw==
+fhir-works-on-aws-interface@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-4.0.0.tgz#4d857dc62a867fba596a02fd481034a94ca93ac0"
+  integrity sha512-7onyEoHuwd+xQoMl6OlugCSahhtrYDNgmy4tYgcsGzTpnbDhQKpDbJUizW1vrpH9t/mPstSYxsBSc1WQ0rl2EA==
 
 figures@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
## Description of changes:
### `verifyAccessToken` changes
- Expected `fhirUser` regex is now a constant `FHIR_USER_REGEX`
  - `fhirUser` is expected to be an absolute url
  - If `fhirUser` claim is not in the right format we reject
- metadata & .well_known changed to pass authorization
- return the userIdentity found by the call to userInfo

### `authorizeAndFilterReadResponse` changes
- For searching filter out resources user does not have access to, does NOT throw error
  - Thought here is if all elements are filtered out the router should call for the next page of search results and try again
- For single reads, throw error if user is not authorized
- For external users (ie their resource is not from our FHIR server) they must use the fully qualified reference to have access
- To check if user is a reference I am converting the JSON to a string then checking for the `fhirUser` claim
- Internal Practitioners can access anything

### `isWriteRequestAuthorized` changes
- Make this Practitioner only action

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
