### PR TITLE
chore: We no longer require Auth for metadata route, because router does not Authorize metadata route

### DIFF
--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -316,17 +316,6 @@ describe('verifyAccessToken; scopes are in an array', () => {
     });
 });
 
-describe('verifyAccessToken; metadata and well-known route', () => {
-    const cases = [
-        ['metadata', { accessToken: '', operation: 'read', resourceType: 'metadata' }],
-        ['well-known', { accessToken: '', operation: 'read', resourceType: '.well-known' }],
-    ];
-    const authZHandler: SMARTHandler = new SMARTHandler(authZConfig, apiUrl);
-    test.each(cases)('CASE: %p', async (_firstArg, request) => {
-        expect(authZHandler.verifyAccessToken(request as VerifyAccessTokenRequest)).resolves.toEqual({});
-    });
-});
-
 describe('verifyAccessToken; scopes are space delimited', () => {
     const spaceScopesCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
         [

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -53,13 +53,6 @@ export class SMARTHandler implements Authorization {
     }
 
     async verifyAccessToken(request: VerifyAccessTokenRequest): Promise<KeyValueMap> {
-        if (
-            request.operation === 'read' &&
-            (request.resourceType === 'metadata' || request.resourceType === '.well-known')
-        ) {
-            return {};
-        }
-
         // The access_token will be verified by hitting the authZUserInfoUrl (token introspection)
         // Decoding first to determine if it passes scope & claims check first
         const decoded = decode(request.accessToken, { json: true }) || {};


### PR DESCRIPTION
Description of changes:
chore: We no longer require Auth for metadata route, because router does not Authorize metadata route
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
