### PR TITLE
[feat] Add Auth support for Bundles, Bulk Data, and allowedResourcesForAuth

### DIFF
--- a/src/smartConfig.ts
+++ b/src/smartConfig.ts
@@ -41,6 +41,19 @@ export type ScopeType = 'patient' | 'user' | 'system';
 export type LaunchType = 'patient' | 'encounter';
 export type IdentityType = 'Patient' | 'Practitioner' | 'Person ' | 'RelatedPerson';
 
+export type SmartScope = ClinicalSmartScope | LaunchSmartScope;
+
+export interface ClinicalSmartScope {
+    scopeType: ScopeType;
+    resourceType: string;
+    accessType: AccessModifier;
+}
+
+export interface LaunchSmartScope {
+    scopeType: 'launch';
+    launchType: LaunchType | undefined;
+}
+
 // Determines what each scope has access to
 export type ScopeRule = {
     [scopeType in ScopeType]: AccessRule;

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -78,6 +78,10 @@ const launchEncounterAccess: string =
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsImxhdW5jaC9lbmNvdW50ZXIiXSwic3ViIjoic21heWRhNDRAZ21haWwuY29tIiwiZmhpclVzZXIiOiJQYXRpZW50LzEyMzQifQ.Nl6yRFGCFnSXszg9kBHS4sbMQio7YnOUajGWOkaLdUA';
 const manyReadAccess: string =
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsImxhdW5jaC9lbmNvdW50ZXIiLCJwYXRpZW50L1BhdGllbnQucmVhZCIsInBhdGllbnQvT2JzZXJ2YXRpb24ucmVhZCJdLCJzdWIiOiJzbWF5ZGE0NEBnbWFpbC5jb20iLCJmaGlyVXNlciI6IlBhdGllbnQvMTIzNCJ9.k_uqVL_uXo49ETrhSwaNXw0LYDadvt4LJuwrKh-0FJo';
+const practitionerUserAllAccess: string =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsImxhdW5jaC9lbmNvdW50ZXIiLCJwYXRpZW50L1BhdGllbnQucmVhZCIsInBhdGllbnQvT2JzZXJ2YXRpb24ucmVhZCIsInVzZXIvKi4qIl0sInN1YiI6InNtYXlkYTQ0QGdtYWlsLmNvbSIsImZoaXJVc2VyIjoiUHJhY3RpdGlvbmVyLzEyMzQifQ.hUvJkUw108XDDw7n6KrRvKbzMWSfp84kt4-qqKCRXA4';
+const practitionerUserReadAccess: string =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsImxhdW5jaC9lbmNvdW50ZXIiLCJwYXRpZW50L1BhdGllbnQucmVhZCIsInBhdGllbnQvT2JzZXJ2YXRpb24ucmVhZCIsInVzZXIvKi5yZWFkIl0sInN1YiI6InNtYXlkYTQ0QGdtYWlsLmNvbSIsImZoaXJVc2VyIjoiUHJhY3RpdGlvbmVyLzEyMzQifQ.85sfPi7_PoNS4zhUeoQWv-dvEUQSwga-h77DT6SXH_M';
 const manyWriteAccess: string =
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsInVzZXIvUGF0aWVudC53cml0ZSIsInN5c3RlbS9PYnNlcnZhdGlvbi53cml0ZSIsInBhdGllbnQvKi53cml0ZSJdLCJzdWIiOiJzbWF5ZGE0NEBnbWFpbC5jb20iLCJmaGlyVXNlciI6IlBhdGllbnQvMTIzNCJ9.tRx8pf60I98vUJI7Q87sZkvI24ii6ADQ_jSw88Q42EY';
 const allSysAccess: string =
@@ -323,6 +327,76 @@ describe('verifyAccessToken; scopes are in an array', () => {
         }
         const identity = addScopeToUserIdentity(
             patientIdentityWithoutScopes,
+            (<VerifyAccessTokenRequest>request).accessToken,
+        );
+        return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toEqual(identity);
+    });
+});
+
+describe('verifyAccessToken; System level export requests', () => {
+    const arrayScopesCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
+        [
+            'Read and Write Access: initiate-export',
+            {
+                accessToken: practitionerUserAllAccess,
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'initiate-export' },
+            },
+            true,
+        ],
+        [
+            'Read Access: initiate-export',
+            {
+                accessToken: practitionerUserReadAccess,
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'initiate-export' },
+            },
+            true,
+        ],
+        [
+            'Read and Write Access: get-status-export',
+            {
+                accessToken: practitionerUserAllAccess,
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'get-status-export' },
+            },
+            true,
+        ],
+        [
+            'Read and Write Access: cancel-export',
+            {
+                accessToken: practitionerUserAllAccess,
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'cancel-export' },
+            },
+            true,
+        ],
+        [
+            'No User read access: initiate-export',
+            {
+                accessToken: manyReadAccess,
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'cancel-export' },
+            },
+            false,
+        ],
+    ];
+
+    const authZHandler: SMARTHandler = new SMARTHandler(authZConfig, apiUrl, '4.0.1');
+    test.each(arrayScopesCases)('CASE: %p', (_firstArg, request, isValid) => {
+        mock.onGet(authZConfig.userInfoEndpoint).reply(200, practitionerIdentityWithoutScopes);
+        if (!isValid) {
+            return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).rejects.toThrowError(
+                UnauthorizedError,
+            );
+        }
+        const identity = addScopeToUserIdentity(
+            practitionerIdentityWithoutScopes,
             (<VerifyAccessTokenRequest>request).accessToken,
         );
         return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toEqual(identity);

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -845,11 +845,40 @@ describe('isBundleRequestAuthorized', () => {
 
         if (!isAuthorized) {
             await expect(authZHandler.isBundleRequestAuthorized(request)).rejects.toThrowError(
-                new UnauthorizedError('An operation with the Bundle is not authorized'),
+                new UnauthorizedError('An entry within the Bundle is not authorized'),
             );
         } else {
             await expect(authZHandler.isBundleRequestAuthorized(request)).resolves.not.toThrow();
         }
+    });
+
+    test('Bundle request with first Bundle entry passing and second Bundle entry failing', async () => {
+        const userIdentity = clone(practitionerIdentityWithoutScopes);
+        // Requester has permission to write Observation but no permission to read Observation
+        userIdentity.scopes = ['user/Observation.write'];
+        const request: AuthorizationBundleRequest = {
+            userIdentity,
+            requests: [
+                {
+                    operation: 'create',
+                    resource: {},
+                    fullUrl: '',
+                    resourceType: 'Observation',
+                    id: '160265f7-e8c2-45ca-a1bc-317399e23549',
+                },
+                {
+                    operation: 'read',
+                    resource: {},
+                    fullUrl: '',
+                    resourceType: 'Observation',
+                    id: 'fcfe413c-c62d-4097-9e31-02ff6ff523ad',
+                },
+            ],
+        };
+
+        await expect(authZHandler.isBundleRequestAuthorized(request)).rejects.toThrowError(
+            new UnauthorizedError('An entry within the Bundle is not authorized'),
+        );
     });
 });
 

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -845,7 +845,7 @@ describe('isBundleRequestAuthorized', () => {
 
         if (!isAuthorized) {
             await expect(authZHandler.isBundleRequestAuthorized(request)).rejects.toThrowError(
-                new UnauthorizedError('Bundle operation is not authorized'),
+                new UnauthorizedError('An operation with the Bundle is not authorized'),
             );
         } else {
             await expect(authZHandler.isBundleRequestAuthorized(request)).resolves.not.toThrow();
@@ -862,6 +862,13 @@ describe('getAllowedResourceTypesForOperation', () => {
         [
             'search-type operation: read scope: returns [Patient, Observation]',
             ['user/Patient.read', 'user/Observation.read'],
+            'search-type',
+            ['Patient', 'Observation'],
+        ],
+        // if there are duplicated scopeResourceType we return an array with the duplicates removed
+        [
+            'search-type operation: read scope: duplicated Observation scopeResourceType still returns [Patient, Observation]',
+            ['user/Patient.read', 'patient/Observation.read', 'user/Observation.read'],
             'search-type',
             ['Patient', 'Observation'],
         ],

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -102,7 +102,7 @@ const apiUrl = 'https://fhir.server.com/dev/';
 const patientId = 'Patient/1234';
 const patientIdentityWithoutScopes = { [authZConfig.fhirUserClaimKey]: `${apiUrl}${patientId}` };
 const practitionerIdentityWithoutScopes = { [authZConfig.fhirUserClaimKey]: `${apiUrl}Practitioner/1234` };
-const validExternalPractitionerIdentity = { [authZConfig.fhirUserClaimKey]: `${apiUrl}test/Practitioner/1234` };
+const externalPractitionerIdentityWithoutScopes = { [authZConfig.fhirUserClaimKey]: `${apiUrl}test/Practitioner/1234` };
 
 const validPatient = {
     resourceType: 'Patient',
@@ -212,7 +212,7 @@ const validPatientEncounter = {
     participant: [
         {
             individual: {
-                reference: validExternalPractitionerIdentity[authZConfig.fhirUserClaimKey],
+                reference: externalPractitionerIdentityWithoutScopes[authZConfig.fhirUserClaimKey],
             },
         },
     ],
@@ -624,7 +624,7 @@ describe('authorizeAndFilterReadResponse', () => {
         [
             'READ: external Practitioner able to read Encounter',
             {
-                userIdentity: validExternalPractitionerIdentity,
+                userIdentity: externalPractitionerIdentityWithoutScopes,
                 operation: 'read',
                 readResponse: validPatientEncounter,
             },
@@ -634,7 +634,7 @@ describe('authorizeAndFilterReadResponse', () => {
         [
             'READ: external Practitioner unable to read Observation',
             {
-                userIdentity: validExternalPractitionerIdentity,
+                userIdentity: externalPractitionerIdentityWithoutScopes,
                 operation: 'read',
                 readResponse: validPatientObservation,
             },
@@ -684,7 +684,7 @@ describe('authorizeAndFilterReadResponse', () => {
         [
             'SEARCH: external Practitioner able to search and filtered to just the encounter',
             {
-                userIdentity: validExternalPractitionerIdentity,
+                userIdentity: externalPractitionerIdentityWithoutScopes,
                 operation: 'search-type',
                 readResponse: searchAllEntitiesMatch,
             },
@@ -739,7 +739,7 @@ describe('isWriteRequestAuthorized', () => {
         [
             'External practitioner unable to write Patient',
             {
-                userIdentity: validExternalPractitionerIdentity,
+                userIdentity: externalPractitionerIdentityWithoutScopes,
                 operation: 'vread',
                 resourceBody: validPatient,
             },

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -92,6 +92,7 @@ export class SMARTHandler implements Authorization {
         //     console.error('Post to authZUserInfoUrl failed', e);
         // }
 
+        // Code for testing locally, code will be deleted before merging
         const response: any = {
             data: {
                 fhirUser: 'https://API_URL.com/Practitioner/123',
@@ -176,6 +177,7 @@ export class SMARTHandler implements Authorization {
             const scope = scopes[i];
             const validOperations = this.getValidOperationsForScope(scope);
             console.log('validOperations', validOperations);
+            // If the scope allows request.operation, get the resources allowed for that operation as defined by 'this.operationToAllowedResources'
             if (validOperations.includes(request.operation)) {
                 let match = scope.match(SMARTHandler.LAUNCH_SCOPE_REGEX);
                 if (!match) {
@@ -186,20 +188,17 @@ export class SMARTHandler implements Authorization {
                     const allowedResourcesForScope = this.operationToAllowedResources[request.operation];
                     if (scopeType === 'launch') {
                         const { launchType } = match.groups!;
-                        // TODO: should launch have access to only certain resourceTypes?
                         if (launchType === 'patient' && allowedResourcesForScope.includes('Patient')) {
                             allowedResources = allowedResources.concat('Patient');
                         } else if (launchType === 'encounter' && allowedResourcesForScope.includes('Encounter')) {
                             allowedResources = allowedResources.concat('Encounter');
                         }
                     } else if (['patient', 'user', 'system'].includes(scopeType)) {
-                        const { scopeResourceType, accessType } = match.groups!;
-                        if (['*', 'read'].includes(accessType)) {
-                            if (scopeResourceType === '*') {
-                                allowedResources = allowedResources.concat(allowedResourcesForScope);
-                            } else if (allowedResourcesForScope.includes(scopeResourceType)) {
-                                allowedResources = allowedResources.concat(scopeResourceType);
-                            }
+                        const { scopeResourceType } = match.groups!;
+                        if (scopeResourceType === '*') {
+                            allowedResources = allowedResources.concat(allowedResourcesForScope);
+                        } else if (allowedResourcesForScope.includes(scopeResourceType)) {
+                            allowedResources = allowedResources.concat(scopeResourceType);
                         }
                     }
                 }
@@ -334,8 +333,6 @@ export class SMARTHandler implements Authorization {
                 }
             }
         }
-
-        console.log('validOperations before', validOperations);
         return validOperations;
     }
 

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -86,22 +86,22 @@ export class SMARTHandler implements Authorization {
         }
 
         // verify token
-        // let response;
-        // try {
-        //     response = await axios.get(this.config.userInfoEndpoint, {
-        //         headers: { Authorization: `Bearer ${request.accessToken}` },
-        //     });
-        // } catch (e) {
-        //     console.error('Post to authZUserInfoUrl failed', e);
-        // }
+        let response;
+        try {
+            response = await axios.get(this.config.userInfoEndpoint, {
+                headers: { Authorization: `Bearer ${request.accessToken}` },
+            });
+        } catch (e) {
+            console.error('Post to authZUserInfoUrl failed', e);
+        }
 
         // Code for testing locally, code will be deleted before merging
-        const response: any = {
-            data: {
-                fhirUser: 'https://API_URL.com/Practitioner/123',
-                sub: 'fakeSub1',
-            },
-        };
+        // const response: any = {
+        //     data: {
+        //         fhirUser: 'https://API_URL.com/Practitioner/123',
+        //         sub: 'fakeSub1',
+        //     },
+        // };
 
         const { fhirUserClaimKey } = this.config;
         if (!response || !response.data[fhirUserClaimKey]) {

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -21,7 +21,6 @@ import {
     FhirVersion,
     BASE_STU3_RESOURCES,
     BulkDataAuth,
-    R4_PATIENT_COMPARTMENT_RESOURCES,
 } from 'fhir-works-on-aws-interface';
 import axios from 'axios';
 import {

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -179,6 +179,7 @@ export class SMARTHandler implements Authorization {
             const scope = request.userIdentity.scopes[i];
             try {
                 const smartScope = this.convertScopeToSmartScope(scope);
+                // We only get allowedResourceTypes for ClinicalSmartScope
                 if (['patient', 'user', 'system'].includes(smartScope.scopeType)) {
                     const clinicalSmartScope = <ClinicalSmartScope>smartScope;
                     const validOperations = this.getValidOperationsForScopeTypeAndAccessType(
@@ -200,7 +201,7 @@ export class SMARTHandler implements Authorization {
                     }
                 }
             } catch (e) {
-                // We only get allowedResourceTypes for ClinicalSmartScope
+                // Caused by trying to convert non-SmartScope to SmartScope, for example converting scope 'openid' or 'profile'
             }
         }
         allowedResources = [...new Set(allowedResources)];

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -76,8 +76,6 @@ export class SMARTHandler implements Authorization {
 
         // verify scope
         const scopes = this.getScopes(decoded);
-        console.log('request', request);
-        console.log('scopes', scopes);
         if (!this.areScopesSufficient(scopes, request.operation, request.resourceType)) {
             console.error(
                 `User supplied scopes are insufficient\nscopes: ${scopes}\noperation: ${request.operation}\nresourceType: ${request.resourceType}`,
@@ -94,14 +92,6 @@ export class SMARTHandler implements Authorization {
         } catch (e) {
             console.error('Post to authZUserInfoUrl failed', e);
         }
-
-        // Code for testing locally, code will be deleted before merging
-        // response = {
-        //     data: {
-        //         fhirUser: 'https://API_URL.com/Practitioner/123',
-        //         sub: 'fakeSub1',
-        //     },
-        // };
 
         const { fhirUserClaimKey } = this.config;
         if (!response || !response.data[fhirUserClaimKey]) {
@@ -142,7 +132,6 @@ export class SMARTHandler implements Authorization {
     }
 
     async isBundleRequestAuthorized(request: AuthorizationBundleRequest): Promise<void> {
-        console.log('AuthorizationBundleRequest', request);
         const { scopes } = request.userIdentity;
         request.requests.forEach((req: BatchReadWriteRequest) => {
             if (!this.areScopesSufficient(scopes, req.operation, req.resourceType)) {
@@ -171,11 +160,9 @@ export class SMARTHandler implements Authorization {
     }
 
     async getAllowedResourceTypesForOperation(request: AllowedResourceTypesForOperationRequest): Promise<string[]> {
-        console.log('beginning of getAllowedResourceTypesForOperation');
         let allowedResources: string[] = [];
         request.userIdentity.scopes.forEach((scope: string) => {
             const validOperations = this.getValidOperationsForScope(scope, request.operation);
-            console.log('validOperations', validOperations);
             // If the scope allows request.operation, get all the resources allowed for that operation as defined by the requester's scopes
             if (validOperations.includes(request.operation)) {
                 const match = scope.match(SMARTHandler.CLINICAL_SCOPE_REGEX);
@@ -195,7 +182,6 @@ export class SMARTHandler implements Authorization {
             }
         });
         allowedResources = [...new Set(allowedResources)];
-        console.log('allowedResources', allowedResources);
         return allowedResources;
     }
 
@@ -287,7 +273,6 @@ export class SMARTHandler implements Authorization {
         reqOperation: TypeOperation | SystemOperation,
         reqResourceType?: string,
     ): (TypeOperation | SystemOperation)[] {
-        console.log('scope, resourceType', scope, reqResourceType);
         const { scopeRule } = this.config;
         let match = scope.match(SMARTHandler.LAUNCH_SCOPE_REGEX);
         if (!match) {
@@ -327,7 +312,6 @@ export class SMARTHandler implements Authorization {
                 }
             }
         }
-        console.log('validOperations', validOperations);
         return validOperations;
     }
 

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -89,21 +89,21 @@ export class SMARTHandler implements Authorization {
         }
 
         // verify token
-        // let response;
-        // try {
-        //     response = await axios.get(this.config.userInfoEndpoint, {
-        //         headers: { Authorization: `Bearer ${request.accessToken}` },
-        //     });
-        // } catch (e) {
-        //     console.error('Post to authZUserInfoUrl failed', e);
-        // }
+        let response;
+        try {
+            response = await axios.get(this.config.userInfoEndpoint, {
+                headers: { Authorization: `Bearer ${request.accessToken}` },
+            });
+        } catch (e) {
+            console.error('Post to authZUserInfoUrl failed', e);
+        }
 
-        const response: any = {
-            data: {
-                fhirUser: 'https://API_URL.com/Practitioner/123',
-                sub: 'fakeSub1',
-            },
-        };
+        // const response: any = {
+        //     data: {
+        //         fhirUser: 'https://API_URL.com/Practitioner/123',
+        //         sub: 'fakeSub1',
+        //     },
+        // };
 
         const { fhirUserClaimKey } = this.config;
         if (!response || !response.data[fhirUserClaimKey]) {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
An overview of the major design choices in this PR is listed below.

* Adding scopes to the `userIdentity` object returned by `verifyAccessToken`. `scopes` is needed later on by `isBundleRequestAuthorized` and `getAllowedResourceTypesForOperation`. These two methods are called in the `handler` classes of the `router` package. 

* Added `operationToAllowedResources` to the constructor because `getAllowedResourceTypesForOperation` needs to know what operations are allowed by each resource. So for example the operation `search-type` can be performed on resources: Patient, Observation, etc...

* Functions implemented `isBundleRequestAuthorized`, `getAllowedResourceTypesForOperation`, and `isAccessBulkDataJobAllowed` 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
