### PR TITLE
Reducing access modifiers to protected

### DIFF
--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -36,13 +36,13 @@ export class SMARTHandler implements Authorization {
         'history-system',
     ];
 
-    private readonly typesWithWriteAccess: IdentityType[] = ['Practitioner'];
+    protected readonly typesWithWriteAccess: IdentityType[] = ['Practitioner'];
 
-    private readonly version: number = 1.0;
+    protected readonly version: number = 1.0;
 
-    private readonly config: SMARTConfig;
+    protected readonly config: SMARTConfig;
 
-    private readonly apiUrl: string;
+    protected readonly apiUrl: string;
 
     constructor(config: SMARTConfig, apiUrl: string) {
         if (config.version !== this.version) {
@@ -185,7 +185,7 @@ export class SMARTHandler implements Authorization {
         throw new UnauthorizedError("Requester's identity is in the incorrect format");
     }
 
-    private areScopesSufficient(
+    protected areScopesSufficient(
         scopes: string[],
         operation: TypeOperation | SystemOperation,
         resourceType?: string,


### PR DESCRIPTION
Description of changes:

This change reduces the access modifiers of certain methods and properties in the `SMARTHandler` such that subclassing by extending this class can more easily override method implementations without running into errors about unaccessible private methods/properties. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
