### PR TITLE
feat: implement patient scope; remove system & launch scopes

### DIFF
--- a/src/regExpressions.test.ts
+++ b/src/regExpressions.test.ts
@@ -8,34 +8,22 @@ import { FHIR_USER_REGEX, FHIR_RESOURCE_REGEX } from './smartAuthorizationHelper
 
 describe('CLINICAL_SCOPE_REGEX', () => {
     const testCases = [
-        ['patient', 'Patient', 'read', true],
-        ['user', 'Patient', 'read', true],
-        ['system', 'Patient', 'read', false],
-        ['patient', 'Patient', 'write', true],
-        ['patient', 'Patient', '*', true],
-        ['patient', 'Observation', 'read', true],
-        ['patient', 'FakeResource', 'write', true],
-        ['patient', '*', 'write', true],
-        ['patient', 'uncapitalizedResource', 'write', false],
-        ['fake', 'Patient', 'write', false],
-        ['patient', 'Patient', 'fake', false],
-        ['patient', 'Patient1', '*', false],
-        ['', 'Patient', 'read', false],
-        ['patient', '', 'read', false],
-        ['patient', 'Patient', '', false],
+        ['patient', 'Patient', 'read'],
+        ['user', 'Patient', 'read'],
+        ['patient', 'Patient', 'write'],
+        ['patient', 'Patient', '*'],
+        ['patient', 'Observation', 'read'],
+        ['patient', 'FakeResource', 'write'],
+        ['patient', '*', 'write'],
     ];
-    test.each(testCases)('CASE: %p/%p.%p; expect: %p', async (scopeType, scopeResourceType, accessType, isSuccess) => {
+    test.each(testCases)('CASE: %p/%p.%p; expect: %p', async (scopeType, scopeResourceType, accessType) => {
         const expectedStr = `${scopeType}/${scopeResourceType}.${accessType}`;
         const actualMatch = expectedStr.match(CLINICAL_SCOPE_REGEX);
-        if (isSuccess) {
-            expect(actualMatch).toBeTruthy();
-            expect(actualMatch!.groups).toBeTruthy();
-            expect(actualMatch!.groups!.scopeType).toEqual(scopeType);
-            expect(actualMatch!.groups!.scopeResourceType).toEqual(scopeResourceType);
-            expect(actualMatch!.groups!.accessType).toEqual(accessType);
-        } else {
-            expect(actualMatch).toBeFalsy();
-        }
+        expect(actualMatch).toBeTruthy();
+        expect(actualMatch!.groups).toBeTruthy();
+        expect(actualMatch!.groups!.scopeType).toEqual(scopeType);
+        expect(actualMatch!.groups!.scopeResourceType).toEqual(scopeResourceType);
+        expect(actualMatch!.groups!.accessType).toEqual(accessType);
     });
     const uniqueTestCases = [
         ['patient.Patient/read'],
@@ -43,6 +31,14 @@ describe('CLINICAL_SCOPE_REGEX', () => {
         ['patient/Patient.read patient/Patient.read'],
         ['launch/patient'],
         ['patient.Patient/read '],
+        ['patient/uncapitalizedResource.write'],
+        ['fake/Patient.write'],
+        ['patient/Patient.fake'],
+        ['patient/Patient1.*'],
+        ['/Patient.read'],
+        ['patient/.read'],
+        ['patient/Patient.'],
+        ['system/Patient.read'],
     ];
     test.each(uniqueTestCases)('CASE: %p; expect: false', async scope => {
         const actualMatch = scope.match(CLINICAL_SCOPE_REGEX);
@@ -52,40 +48,25 @@ describe('CLINICAL_SCOPE_REGEX', () => {
 
 describe('FHIR_USER_REGEX', () => {
     const testCases = [
-        ['https://fhir.server.com/dev/', 'Patient', 'id', true],
-        ['http://fhir.server.com/dev/', 'Patient', 'id', true],
-        ['http://fhir.server.com/dev-.:/%/$/2/', 'Patient', 'id', true],
-        ['http://localhost/projectname/', 'Patient', 'id', true],
-        ['http://127.0.0.1/project_name/', 'Patient', 'id', true],
-        ['https://127.0.0.1:8080/project_name/', 'Patient', 'id', true],
-        ['https://fhir.server.com/dev/', 'Practitioner', 'id', true],
-        ['https://fhir.server.com/dev/', 'RelatedPerson', 'id', true],
-        ['https://fhir.server.com/dev/', 'Person', 'id', true],
-        ['https://fhir.server.com/dev/', 'Patient', 'idID1234-123.aBc', true],
-        ['', 'Patient', 'id', false],
-        ['https://fhir.server.com/dev/', '', 'id', false],
-        ['https://fhir.server.com/dev/', 'Patient', '', false],
-        ['fhir.server.com/dev/', 'Patient', 'id', false],
-        ['https://fhir.server.com/dev', 'Patient', 'id', false],
-        ['127.0.0.1/project_name', 'Patient', 'id', false],
-        ['https://fhir.server.com/dev/', 'Observation', 'id', false],
-        ['https://fhir.server.com/dev/', 'Patient', 'i_d', false],
-        ['https://fhir.server.com/dev/', 'Patient', 'i#d', false],
-        ['https://fhir.server.com/dev/', 'Patient', 'id ', false],
-        [' https://fhir.server.com/dev/', 'Patient', 'id', false],
+        ['https://fhir.server.com/dev/', 'Patient', 'id'],
+        ['http://fhir.server.com/dev/', 'Patient', 'id'],
+        ['http://fhir.server.com/dev-.:/%/$/2/', 'Patient', 'id'],
+        ['http://localhost/projectname/', 'Patient', 'id'],
+        ['http://127.0.0.1/project_name/', 'Patient', 'id'],
+        ['https://127.0.0.1:8080/project_name/', 'Patient', 'id'],
+        ['https://fhir.server.com/dev/', 'Practitioner', 'id'],
+        ['https://fhir.server.com/dev/', 'RelatedPerson', 'id'],
+        ['https://fhir.server.com/dev/', 'Person', 'id'],
+        ['https://fhir.server.com/dev/', 'Patient', 'idID1234-123.aBc'],
     ];
-    test.each(testCases)('CASE: %p%p/%p; expect: %p', async (hostname, resourceType, id, isSuccess) => {
+    test.each(testCases)('CASE: %p%p/%p; expect: %p', async (hostname, resourceType, id) => {
         const expectedStr = `${hostname}${resourceType}/${id}`;
         const actualMatch = expectedStr.match(FHIR_USER_REGEX);
-        if (isSuccess) {
-            expect(actualMatch).toBeTruthy();
-            expect(actualMatch!.groups).toBeTruthy();
-            expect(actualMatch!.groups!.hostname).toEqual(hostname);
-            expect(actualMatch!.groups!.resourceType).toEqual(resourceType);
-            expect(actualMatch!.groups!.id).toEqual(id);
-        } else {
-            expect(actualMatch).toBeFalsy();
-        }
+        expect(actualMatch).toBeTruthy();
+        expect(actualMatch!.groups).toBeTruthy();
+        expect(actualMatch!.groups!.hostname).toEqual(hostname);
+        expect(actualMatch!.groups!.resourceType).toEqual(resourceType);
+        expect(actualMatch!.groups!.id).toEqual(id);
     });
     const uniqueTestCases = [
         ['patient/Patient.read'],
@@ -93,6 +74,17 @@ describe('FHIR_USER_REGEX', () => {
         ['just-an-id-1234'],
         ['Patient'],
         ['https://fhir.server.com/dev/'],
+        ['Patient/id'],
+        ['https://fhir.server.com/dev//id'],
+        ['https://fhir.server.com/dev/Patient/'],
+        ['fhir.server.com/dev/Patient/id'],
+        ['https://fhir.server.com/devPatient/id'],
+        ['127.0.0.1/project_namePatient/id'],
+        ['https://fhir.server.com/dev/Observation/id'],
+        ['https://fhir.server.com/dev/Patient/i_d'],
+        ['https://fhir.server.com/dev/Patient/i#d'],
+        ['https://fhir.server.com/dev/Patient/id '],
+        [' https://fhir.server.com/dev/Patient/id'],
     ];
     test.each(uniqueTestCases)('CASE: %p; expect: false', async scope => {
         const actualMatch = scope.match(FHIR_USER_REGEX);
@@ -101,34 +93,30 @@ describe('FHIR_USER_REGEX', () => {
 });
 describe('FHIR_RESOURCE_REGEX', () => {
     const testCases = [
-        ['https://fhir.server.com/dev/', 'Patient', 'id', true, true],
-        ['http://fhir.server.com/dev-.:/%/$/2/', 'Observation', 'id', true, true],
-        ['http://localhost/projectname/', 'Encounter', 'id', true, true],
-        ['https://127.0.0.1:8080/project_name/', 'Patient', 'id', true, true],
-        ['https://fhir.server.com/dev/', 'Patient', 'idID1234-123.aBc', true, true],
-        ['', 'Patient', 'id', true, false],
-        ['', 'Encounter', 'id', true, false],
-        ['fhir.server.com/dev/', 'Patient', 'id', true, false],
-        ['127.0.0.1/project_name', 'Patient', 'id', true, false],
+        ['https://fhir.server.com/dev/', 'Patient', 'id'],
+        ['http://fhir.server.com/dev-.:/%/$/2/', 'Observation', 'id'],
+        ['http://localhost/projectname/', 'Encounter', 'id'],
+        ['https://127.0.0.1:8080/project_name/', 'Patient', 'id'],
+        ['https://fhir.server.com/dev/', 'Patient', 'idID1234-123.aBc'],
+        ['', 'Patient', 'id'],
+        ['', 'Encounter', 'id'],
     ];
-    test.each(testCases)('CASE: %p%p/%p; expect: %p', async (hostname, resourceType, id, isSuccess, hasHostname) => {
+    test.each(testCases)('CASE: %p%p/%p; expect: %p', async (hostname, resourceType, id) => {
         const expectedStr = `${hostname}${resourceType}/${id}`;
         const actualMatch = expectedStr.match(FHIR_RESOURCE_REGEX);
-        if (isSuccess) {
-            expect(actualMatch).toBeTruthy();
-            expect(actualMatch!.groups).toBeTruthy();
-            expect(actualMatch!.groups!.resourceType).toEqual(resourceType);
-            expect(actualMatch!.groups!.id).toEqual(id);
-            if (hasHostname) {
-                expect(actualMatch!.groups!.hostname).toEqual(hostname);
-            } else {
-                expect(actualMatch!.groups!.hostname).toBeFalsy();
-            }
+        expect(actualMatch).toBeTruthy();
+        expect(actualMatch!.groups).toBeTruthy();
+        expect(actualMatch!.groups!.resourceType).toEqual(resourceType);
+        expect(actualMatch!.groups!.id).toEqual(id);
+        if (hostname) {
+            expect(actualMatch!.groups!.hostname).toEqual(hostname);
         } else {
-            expect(actualMatch).toBeFalsy();
+            expect(actualMatch!.groups!.hostname).toBeFalsy();
         }
     });
     const uniqueTestCases = [
+        ['fhir.server.com/dev/Patient/id'],
+        ['https://127.0.0.1/project_namePatient/id'],
         ['patient/Patient.read'],
         ['launch/encounter'],
         ['just-an-id-1234'],

--- a/src/regExpressions.test.ts
+++ b/src/regExpressions.test.ts
@@ -16,7 +16,7 @@ describe('CLINICAL_SCOPE_REGEX', () => {
         ['patient', 'FakeResource', 'write'],
         ['patient', '*', 'write'],
     ];
-    test.each(testCases)('CASE: %p/%p.%p; expect: %p', async (scopeType, scopeResourceType, accessType) => {
+    test.each(testCases)('CASE: %p/%p.%p; expect: matches', async (scopeType, scopeResourceType, accessType) => {
         const expectedStr = `${scopeType}/${scopeResourceType}.${accessType}`;
         const actualMatch = expectedStr.match(CLINICAL_SCOPE_REGEX);
         expect(actualMatch).toBeTruthy();
@@ -40,7 +40,7 @@ describe('CLINICAL_SCOPE_REGEX', () => {
         ['patient/Patient.'],
         ['system/Patient.read'],
     ];
-    test.each(uniqueTestCases)('CASE: %p; expect: false', async scope => {
+    test.each(uniqueTestCases)('CASE: %p; expect: no match', async scope => {
         const actualMatch = scope.match(CLINICAL_SCOPE_REGEX);
         expect(actualMatch).toBeFalsy();
     });
@@ -59,7 +59,7 @@ describe('FHIR_USER_REGEX', () => {
         ['https://fhir.server.com/dev/', 'Person', 'id'],
         ['https://fhir.server.com/dev/', 'Patient', 'idID1234-123.aBc'],
     ];
-    test.each(testCases)('CASE: %p%p/%p; expect: %p', async (hostname, resourceType, id) => {
+    test.each(testCases)('CASE: %p%p/%p; expect: matches', async (hostname, resourceType, id) => {
         const expectedStr = `${hostname}${resourceType}/${id}`;
         const actualMatch = expectedStr.match(FHIR_USER_REGEX);
         expect(actualMatch).toBeTruthy();
@@ -86,7 +86,7 @@ describe('FHIR_USER_REGEX', () => {
         ['https://fhir.server.com/dev/Patient/id '],
         [' https://fhir.server.com/dev/Patient/id'],
     ];
-    test.each(uniqueTestCases)('CASE: %p; expect: false', async scope => {
+    test.each(uniqueTestCases)('CASE: %p; expect: no match', async scope => {
         const actualMatch = scope.match(FHIR_USER_REGEX);
         expect(actualMatch).toBeFalsy();
     });
@@ -101,7 +101,7 @@ describe('FHIR_RESOURCE_REGEX', () => {
         ['', 'Patient', 'id'],
         ['', 'Encounter', 'id'],
     ];
-    test.each(testCases)('CASE: %p%p/%p; expect: %p', async (hostname, resourceType, id) => {
+    test.each(testCases)('CASE: %p%p/%p; expect: matches', async (hostname, resourceType, id) => {
         const expectedStr = `${hostname}${resourceType}/${id}`;
         const actualMatch = expectedStr.match(FHIR_RESOURCE_REGEX);
         expect(actualMatch).toBeTruthy();
@@ -123,7 +123,7 @@ describe('FHIR_RESOURCE_REGEX', () => {
         ['Patient'],
         ['https://fhir.server.com/dev/'],
     ];
-    test.each(uniqueTestCases)('CASE: %p; expect: false', async scope => {
+    test.each(uniqueTestCases)('CASE: %p; expect: no match', async scope => {
         const actualMatch = scope.match(FHIR_RESOURCE_REGEX);
         expect(actualMatch).toBeFalsy();
     });

--- a/src/smartAuthorizationHelper.test.ts
+++ b/src/smartAuthorizationHelper.test.ts
@@ -1,9 +1,9 @@
 import { UnauthorizedError } from 'fhir-works-on-aws-interface';
-import { authorizeResource, FhirUser, getFhirUser } from './smartAuthorizationHelper';
+import { authorizeResource, FhirResource, getFhirResource, getFhirUser } from './smartAuthorizationHelper';
 
 describe('getFhirUser', () => {
     test('valid fhirUser', () => {
-        expect(getFhirUser({ fhirUser: 'https://fhirServer.com/Practitioner/1234' }, 'fhirUser')).toEqual({
+        expect(getFhirUser('https://fhirServer.com/Practitioner/1234')).toEqual({
             hostname: 'https://fhirServer.com/',
             id: '1234',
             resourceType: 'Practitioner',
@@ -11,13 +11,45 @@ describe('getFhirUser', () => {
     });
     test('invalid fhirUser', () => {
         expect(() => {
-            getFhirUser({ fhirUser: 'invalidFhirUser' }, 'fhirUser');
+            getFhirUser('invalidFhirUser');
         }).toThrowError(new UnauthorizedError("Requester's identity is in the incorrect format"));
+    });
+});
+describe('getFhirResource', () => {
+    const defaultHostname = 'http://default.com';
+    test('valid fhirResource', () => {
+        expect(getFhirResource('https://fhirServer.com/Practitioner/1234', defaultHostname)).toEqual({
+            hostname: 'https://fhirServer.com/',
+            id: '1234',
+            resourceType: 'Practitioner',
+        });
+        expect(getFhirResource('https://fhirServer1234.com/Organization/1234', defaultHostname)).toEqual({
+            hostname: 'https://fhirServer1234.com/',
+            id: '1234',
+            resourceType: 'Organization',
+        });
+    });
+    test('valid fhirResource;; With default hostname', () => {
+        expect(getFhirResource('Practitioner/1234', defaultHostname)).toEqual({
+            hostname: defaultHostname,
+            id: '1234',
+            resourceType: 'Practitioner',
+        });
+        expect(getFhirResource('Organization/1234', defaultHostname)).toEqual({
+            hostname: defaultHostname,
+            id: '1234',
+            resourceType: 'Organization',
+        });
+    });
+    test('invalid fhirResource', () => {
+        expect(() => {
+            getFhirResource('invalidFhirResource', defaultHostname);
+        }).toThrowError(new Error('Resource is in the incorrect format'));
     });
 });
 
 describe('authorizeResource', () => {
-    const fhirUser: FhirUser = {
+    const fhirUser: FhirResource = {
         hostname: 'https://fhirServer.com/',
         id: '1234',
         resourceType: 'Practitioner',
@@ -29,7 +61,7 @@ describe('authorizeResource', () => {
         expect(authorizeResource(fhirUser, {}, 'https://fhirServer.com/')).toEqual(true);
     });
     describe('fhirUser resourceType matches resourceType of resource', () => {
-        const patientFhirUser: FhirUser = {
+        const patientFhirUser: FhirResource = {
             hostname: 'https://fhirServer.com/',
             id: '1234',
             resourceType: 'Patient',

--- a/src/smartAuthorizationHelper.ts
+++ b/src/smartAuthorizationHelper.ts
@@ -29,10 +29,10 @@ export function getFhirResource(resourceValue: string, defaultHostname: string):
     throw new UnauthorizedError('Resource is in the incorrect format');
 }
 
-function isLocalResourceInJsonAsReference(jsonStr: string, fhirUser: FhirResource): boolean {
+function isLocalResourceInJsonAsReference(jsonStr: string, fhirResource: FhirResource): boolean {
     return (
-        jsonStr.includes(`"reference":"${fhirUser.hostname}${fhirUser.resourceType}/${fhirUser.id}"`) ||
-        jsonStr.includes(`"reference":"${fhirUser.resourceType}/${fhirUser.id}"`)
+        jsonStr.includes(`"reference":"${fhirResource.hostname}${fhirResource.resourceType}/${fhirResource.id}"`) ||
+        jsonStr.includes(`"reference":"${fhirResource.resourceType}/${fhirResource.id}"`)
     );
 }
 
@@ -47,7 +47,7 @@ export function authorizeResource(fhirResource: FhirResource, resource: any, api
         return true;
     }
     if (resourceType === resource.resourceType) {
-        // Attempting to look up its own record?
+        // Attempting to look up its own record
         return id === resource.id || isLocalResourceInJsonAsReference(jsonStr, fhirResource);
     }
     return isLocalResourceInJsonAsReference(jsonStr, fhirResource);

--- a/src/smartAuthorizationHelper.ts
+++ b/src/smartAuthorizationHelper.ts
@@ -1,7 +1,7 @@
 import { UnauthorizedError } from 'fhir-works-on-aws-interface';
 
 export const FHIR_USER_REGEX = /^(?<hostname>(http|https):\/\/([A-Za-z0-9\-\\.:%$_]*\/)+)(?<resourceType>Person|Practitioner|RelatedPerson|Patient)\/(?<id>[A-Za-z0-9\-.]+)$/;
-export const FHIR_RESOURCE_REGEX = /(?<hostname>^(http|https):\/\/([A-Za-z0-9\-\\.:%$_]*\/)+)?(?<resourceType>[A-Z][a-zA-Z]+)\/(?<id>[A-Za-z0-9\-.]+)$/;
+export const FHIR_RESOURCE_REGEX = /^(?<hostname>(http|https):\/\/([A-Za-z0-9\-\\.:%$_]*\/)+)?(?<resourceType>[A-Z][a-zA-Z]+)\/(?<id>[A-Za-z0-9\-.]+)$/;
 
 export interface FhirResource {
     hostname: string;
@@ -19,11 +19,8 @@ export function getFhirUser(fhirUserValue: string): FhirResource {
 export function getFhirResource(resourceValue: string, defaultHostname: string): FhirResource {
     const match = resourceValue.match(FHIR_RESOURCE_REGEX);
     if (match) {
-        // eslint-disable-next-line prefer-const
-        let { hostname, resourceType, id } = match.groups!;
-        if (!hostname) {
-            hostname = defaultHostname;
-        }
+        const { resourceType, id } = match.groups!;
+        const hostname = match.groups!.hostname ?? defaultHostname;
         return { hostname, resourceType, id };
     }
     throw new UnauthorizedError('Resource is in the incorrect format');
@@ -36,7 +33,7 @@ function isLocalResourceInJsonAsReference(jsonStr: string, fhirResource: FhirRes
     );
 }
 
-export function authorizeResource(fhirResource: FhirResource, resource: any, apiUrl: string): boolean {
+export function hasReferenceToResource(fhirResource: FhirResource, resource: any, apiUrl: string): boolean {
     const jsonStr = JSON.stringify(resource);
     const { hostname, resourceType, id } = fhirResource;
     if (hostname !== apiUrl) {

--- a/src/smartAuthorizationHelper.ts
+++ b/src/smartAuthorizationHelper.ts
@@ -1,15 +1,14 @@
-import { KeyValueMap, UnauthorizedError } from 'fhir-works-on-aws-interface';
-import { IdentityType } from './smartConfig';
+import { UnauthorizedError } from 'fhir-works-on-aws-interface';
 
 export const FHIR_USER_REGEX = /^(?<hostname>(http|https):\/\/([A-Za-z0-9\-\\.:%$_]*\/)+)(?<resourceType>Person|Practitioner|RelatedPerson|Patient)\/(?<id>[A-Za-z0-9\-.]+)$/;
+export const FHIR_RESOURCE_REGEX = /(?<hostname>^(http|https):\/\/([A-Za-z0-9\-\\.:%$_]*\/)+)?(?<resourceType>[A-Z][a-zA-Z]+)\/(?<id>[A-Za-z0-9\-.]+)$/;
 
-export interface FhirUser {
+export interface FhirResource {
     hostname: string;
-    resourceType: IdentityType;
+    resourceType: string;
     id: string;
 }
-export function getFhirUser(userIdentity: KeyValueMap, fhirUserClaimKey: string): FhirUser {
-    const fhirUserValue = userIdentity[fhirUserClaimKey];
+export function getFhirUser(fhirUserValue: string): FhirResource {
     const match = fhirUserValue.match(FHIR_USER_REGEX);
     if (match) {
         const { hostname, resourceType, id } = match.groups!;
@@ -17,26 +16,39 @@ export function getFhirUser(userIdentity: KeyValueMap, fhirUserClaimKey: string)
     }
     throw new UnauthorizedError("Requester's identity is in the incorrect format");
 }
+export function getFhirResource(resourceValue: string, defaultHostname: string): FhirResource {
+    const match = resourceValue.match(FHIR_RESOURCE_REGEX);
+    if (match) {
+        // eslint-disable-next-line prefer-const
+        let { hostname, resourceType, id } = match.groups!;
+        if (!hostname) {
+            hostname = defaultHostname;
+        }
+        return { hostname, resourceType, id };
+    }
+    throw new UnauthorizedError('Resource is in the incorrect format');
+}
 
-function isLocalUserInJsonAsReference(jsonStr: string, fhirUser: FhirUser) {
+function isLocalResourceInJsonAsReference(jsonStr: string, fhirUser: FhirResource): boolean {
     return (
         jsonStr.includes(`"reference":"${fhirUser.hostname}${fhirUser.resourceType}/${fhirUser.id}"`) ||
         jsonStr.includes(`"reference":"${fhirUser.resourceType}/${fhirUser.id}"`)
     );
 }
 
-export function authorizeResource(fhirUser: FhirUser, resource: any, apiUrl: string): boolean {
+export function authorizeResource(fhirResource: FhirResource, resource: any, apiUrl: string): boolean {
     const jsonStr = JSON.stringify(resource);
-    if (fhirUser.hostname !== apiUrl) {
+    const { hostname, resourceType, id } = fhirResource;
+    if (hostname !== apiUrl) {
         // If requester is not from this FHIR Server they must be a fully qualified reference
-        return jsonStr.includes(`"reference":"${fhirUser.hostname}${fhirUser.resourceType}/${fhirUser.id}"`);
+        return jsonStr.includes(`"reference":"${hostname}${resourceType}/${id}"`);
     }
-    if (fhirUser.resourceType === 'Practitioner') {
+    if (resourceType === 'Practitioner') {
         return true;
     }
-    if (fhirUser.resourceType === resource.resourceType) {
-        // Attempting to look up its own record
-        return fhirUser.id === resource.id || isLocalUserInJsonAsReference(jsonStr, fhirUser);
+    if (resourceType === resource.resourceType) {
+        // Attempting to look up its own record?
+        return id === resource.id || isLocalResourceInJsonAsReference(jsonStr, fhirResource);
     }
-    return isLocalUserInJsonAsReference(jsonStr, fhirUser);
+    return isLocalResourceInJsonAsReference(jsonStr, fhirResource);
 }

--- a/src/smartConfig.ts
+++ b/src/smartConfig.ts
@@ -41,8 +41,8 @@ export type FhirResource = { hostname: string; resourceType: string; id: string 
 
 export interface UserIdentity extends KeyValueMap {
     scopes: string[];
-    fhirUser: FhirResource;
-    launchResources: FhirResource[];
+    fhirUserObject?: FhirResource;
+    patientLaunchContext?: FhirResource;
 }
 
 export interface SMARTConfig {

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -483,6 +483,17 @@ describe('verifyAccessToken; System level export requests', () => {
             true,
         ],
         [
+            'External practitioner: initiate-export; fail',
+            {
+                accessToken: 'fake',
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'initiate-export' },
+            },
+            { ...baseAccessNoScopes, scp: ['user/*.*', 'patient/*.write'], fhirUser: externalPractitionerIdentity },
+            false,
+        ],
+        [
             'No User read access: initiate-export',
             {
                 accessToken: 'fake',
@@ -883,6 +894,31 @@ describe('isWriteRequestAuthorized', () => {
             },
             true,
         ],
+        [
+            'PATCH: missing user/patient context',
+            {
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.write', 'patient/*.write'],
+                },
+                operation: 'patch',
+                resourceBody: { ...validPatient, generalPractitioner: { reference: externalPractitionerIdentity } },
+            },
+            false,
+        ],
+        [
+            'UPDATE: user scope; External practitioner unable to write Patient',
+            {
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.write'],
+                    fhirUserObject: externalPractitionerFhirResource,
+                },
+                operation: 'update',
+                resourceBody: validPatient,
+            },
+            false,
+        ],
     ];
 
     const authZHandler: SMARTHandler = new SMARTHandler(authZConfig, apiUrl, '4.0.1');
@@ -994,6 +1030,15 @@ describe('isBundleRequestAuthorized', () => {
                 scopes: ['patient/Patient.read'],
                 fhirUserObject: practitionerFhirResource,
                 patientLaunchContext: patientFhirResource,
+            },
+            false,
+        ],
+        [
+            'patient with correct scopes; but does not have write access to resource: no error',
+            {
+                ...baseAccessNoScopes,
+                scopes: ['patient/*.*', 'profile'],
+                patientLaunchContext: externalPractitionerFhirResource,
             },
             false,
         ],

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -18,9 +18,14 @@ import {
     AuthorizationBundleRequest,
     GetSearchFilterBasedOnIdentityRequest,
 } from 'fhir-works-on-aws-interface';
-import { decode } from 'jsonwebtoken';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import jwt from 'jsonwebtoken';
 import { SMARTHandler } from './smartHandler';
 import { SMARTConfig, ScopeRule } from './smartConfig';
+import { getScopes } from './smartScopeHelper';
+import { getFhirResource, getFhirUser } from './smartAuthorizationHelper';
+
+jest.mock('jsonwebtoken');
 
 const allReadOperations: (TypeOperation | SystemOperation)[] = [
     'read',
@@ -48,66 +53,54 @@ const scopeRule: ScopeRule = {
     },
     user: {
         read: allReadOperations,
-        write: [],
-    },
-    system: {
-        read: allReadOperations,
         write: allWriteOperations,
-    },
-    launch: {
-        launch: allReadOperations,
-        patient: allReadOperations,
-        encounter: allReadOperations,
     },
 };
 
-const noFHIRScopesAccess: string =
-    'eyJraWQiOiJETmJFNVpJalFmR2FJTEY3RlBmZHVZMjdCQ1R0THZ0QTVCTGRlWUFQcFFRIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSJdLCJzdWIiOiJzbWF5ZGE0NEBnbWFpbC5jb20iLCJmaGlyVXNlciI6IlBhdGllbnQvMTIzNCJ9.wvziVAfCAM3Lmg2xeiZ991fuKtVSIY7uJItBCYfOc_fNceZzCitMTRhbBFBR65C9qPemmJOGgnVIWsy2fWwkWqIS9f4jhYW5VstmxsJpZDpJFi1Junrhb3kFzTQr80yP3unGlQMLv91x4E4RWcmXOr0akh9Z7PuO2M0LUwup4riix4X2do-nqepVp-7PTd-t3AqC8ohK5_vrPbi4YFKOtp7TJEfSm251OMI_TaXr0o83Gr8i25QITo8uZE87mIlWw9Y84mETos2U8fpYfHE1rvTev1zu5Qu38DCZeuppDnftvTvOfZY25TbdjzrUEUNypVGro38UxVoLh9d5rGZZxw';
-const audStringWrongAccess: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdHFxcSIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsInBhdGllbnQvKi4qIl0sInN1YiI6InNtYXlkYTQ0QGdtYWlsLmNvbSIsImZoaXJVc2VyIjoiUGF0aWVudC8xMjM0In0.7SWjgXwiHdZHH9p3GX6ef994ZdPO3XLC2St-HSIpuCA';
-const audArrayWrongAccess: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjpbImFwaTovL2RlZmF1bHRxcXEiXSwiaWF0IjoxNjAzMTE4MTM4LCJleHAiOjE2MDMxMjE3MzgsImNpZCI6IjBvYThtdWF6S1N5azlnUDV5NWQ1IiwidWlkIjoiMDB1ODVvendqaldSZDE3UEI1ZDUiLCJzY3AiOlsiZmhpclVzZXIiLCJvcGVuaWQiLCJwcm9maWxlIiwicGF0aWVudC8qLioiXSwic3ViIjoic21heWRhNDRAZ21haWwuY29tIiwiZmhpclVzZXIiOiJQYXRpZW50LzEyMzQifQ.oSOQuWe-hW6SS8rjczDijBsws9sNHNwwK7eiTnfE1Uw';
-const audArrayValidAccess: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjpbImFwaTovL2RlZmF1bHRxcXEiLCJhcGk6Ly9kZWZhdWx0Il0sImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsImxhdW5jaC9lbmNvdW50ZXIiLCJwYXRpZW50L1BhdGllbnQucmVhZCIsInBhdGllbnQvT2JzZXJ2YXRpb24ucmVhZCJdLCJzdWIiOiJzbWF5ZGE0NEBnbWFpbC5jb20iLCJmaGlyVXNlciI6IlBhdGllbnQvMTIzNCJ9.p9yVl9xYXhin-xMgpxWaWlot1yj0qrMTZxfnqLPv6tA';
-const issWrongAccess: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL2Zha2UvZGVmYXVsdCIsImF1ZCI6ImFwaTovL2RlZmF1bHQiLCJpYXQiOjE2MDMxMTgxMzgsImV4cCI6MTYwMzEyMTczOCwiY2lkIjoiMG9hOG11YXpLU3lrOWdQNXk1ZDUiLCJ1aWQiOiIwMHU4NW96d2pqV1JkMTdQQjVkNSIsInNjcCI6WyJmaGlyVXNlciIsIm9wZW5pZCIsInByb2ZpbGUiLCJwYXRpZW50LyouKiJdLCJzdWIiOiJzbWF5ZGE0NEBnbWFpbC5jb20iLCJmaGlyVXNlciI6IlBhdGllbnQvMTIzNCJ9.KD39_myQqMW5lckO4iS_XAU9Ygs59t5i70EZFFTxe7U';
-const launchAccess: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsImxhdW5jaCJdLCJzdWIiOiJzbWF5ZGE0NEBnbWFpbC5jb20iLCJmaGlyVXNlciI6IlBhdGllbnQvMTIzNCJ9.d7bx2yTIVVuqgxclrJe-TOfRuslTKi5np4hM_B6VQ_o';
-const launchPatientAccess: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsImxhdW5jaC9wYXRpZW50Il0sInN1YiI6InNtYXlkYTQ0QGdtYWlsLmNvbSIsImZoaXJVc2VyIjoiUGF0aWVudC8xMjM0In0.0pXNJUUCUyIfCkbMnyA6c68YT1Yk9gdgy_54gCIvwMI';
-const launchEncounterAccess: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsImxhdW5jaC9lbmNvdW50ZXIiXSwic3ViIjoic21heWRhNDRAZ21haWwuY29tIiwiZmhpclVzZXIiOiJQYXRpZW50LzEyMzQifQ.Nl6yRFGCFnSXszg9kBHS4sbMQio7YnOUajGWOkaLdUA';
-const manyReadAccess: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsImxhdW5jaC9lbmNvdW50ZXIiLCJwYXRpZW50L1BhdGllbnQucmVhZCIsInBhdGllbnQvT2JzZXJ2YXRpb24ucmVhZCJdLCJzdWIiOiJzbWF5ZGE0NEBnbWFpbC5jb20iLCJmaGlyVXNlciI6IlBhdGllbnQvMTIzNCJ9.k_uqVL_uXo49ETrhSwaNXw0LYDadvt4LJuwrKh-0FJo';
-const practitionerUserAllAccess: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsImxhdW5jaC9lbmNvdW50ZXIiLCJwYXRpZW50L1BhdGllbnQucmVhZCIsInBhdGllbnQvT2JzZXJ2YXRpb24ucmVhZCIsInVzZXIvKi4qIl0sInN1YiI6InNtYXlkYTQ0QGdtYWlsLmNvbSIsImZoaXJVc2VyIjoiUHJhY3RpdGlvbmVyLzEyMzQifQ.hUvJkUw108XDDw7n6KrRvKbzMWSfp84kt4-qqKCRXA4';
-const practitionerUserReadAccess: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsImxhdW5jaC9lbmNvdW50ZXIiLCJwYXRpZW50L1BhdGllbnQucmVhZCIsInBhdGllbnQvT2JzZXJ2YXRpb24ucmVhZCIsInVzZXIvKi5yZWFkIl0sInN1YiI6InNtYXlkYTQ0QGdtYWlsLmNvbSIsImZoaXJVc2VyIjoiUHJhY3RpdGlvbmVyLzEyMzQifQ.85sfPi7_PoNS4zhUeoQWv-dvEUQSwga-h77DT6SXH_M';
-const manyWriteAccess: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbImZoaXJVc2VyIiwib3BlbmlkIiwicHJvZmlsZSIsInVzZXIvUGF0aWVudC53cml0ZSIsInN5c3RlbS9PYnNlcnZhdGlvbi53cml0ZSIsInBhdGllbnQvKi53cml0ZSJdLCJzdWIiOiJzbWF5ZGE0NEBnbWFpbC5jb20iLCJmaGlyVXNlciI6IlBhdGllbnQvMTIzNCJ9.tRx8pf60I98vUJI7Q87sZkvI24ii6ADQ_jSw88Q42EY';
-const allSysAccess: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjpbInN5c3RlbS8qLioiXSwic3ViIjoic21heWRhNDRAZ21haWwuY29tIiwiZmhpclVzZXIiOiJQYXRpZW50LzEyMzQifQ.prsPxDrXt3vg1WpKJCLSHm9bFItL3wItYMb8Hvk6K3I';
-const manyReadAccessScopeSpaces: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjoiZmhpclVzZXIgb3BlbmlkIHByb2ZpbGUgbGF1bmNoL2VuY291bnRlciBwYXRpZW50L1BhdGllbnQucmVhZCBwYXRpZW50L09ic2VydmF0aW9uLnJlYWQiLCJzdWIiOiJzbWF5ZGE0NEBnbWFpbC5jb20iLCJmaGlyVXNlciI6IlBhdGllbnQvMTIzNCJ9.XXzFDtWFUreMDg39xTDlC3cNBc6TVZZ6i4IRD-6RcOA';
-const manyReadAccessScopeSpacesJustLaunch: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOjEsImp0aSI6IkFULjZhN2tuY1RDcHUxWDllbzJRaEgxel9XTFVLNFR5VjQzbl85STZrWk53UFkiLCJpc3MiOiJodHRwczovL2Rldi02NDYwNjExLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTYwMzExODEzOCwiZXhwIjoxNjAzMTIxNzM4LCJjaWQiOiIwb2E4bXVhektTeWs5Z1A1eTVkNSIsInVpZCI6IjAwdTg1b3p3ampXUmQxN1BCNWQ1Iiwic2NwIjoiZmhpclVzZXIgb3BlbmlkIHByb2ZpbGUgbGF1bmNoIiwic3ViIjoic21heWRhNDRAZ21haWwuY29tIiwiZmhpclVzZXIiOiJQYXRpZW50LzEyMzQifQ.mExtrUuJhXRaKlpJ72-3CrsX5CezkYC-tVY1dg4frlw';
 const expectedAud = 'api://default';
 const expectedIss = 'https://dev-6460611.okta.com/oauth2/default';
 const authZConfig: SMARTConfig = {
     version: 1.0,
     scopeKey: 'scp',
-    scopeValueType: 'array',
     scopeRule,
     expectedAudValue: expectedAud,
     expectedIssValue: expectedIss,
     fhirUserClaimKey: 'fhirUser',
+    launchContextKeyPrefix: 'launch_response_',
     userInfoEndpoint: `${expectedIss}/userInfo`,
 };
 const apiUrl = 'https://fhir.server.com/dev/';
 const patientId = 'Patient/1234';
-const patientIdentityWithoutScopes = { [authZConfig.fhirUserClaimKey]: `${apiUrl}${patientId}` };
-const practitionerIdentityWithoutScopes = { [authZConfig.fhirUserClaimKey]: `${apiUrl}Practitioner/1234` };
-const externalPractitionerIdentityWithoutScopes = { [authZConfig.fhirUserClaimKey]: `${apiUrl}test/Practitioner/1234` };
+const practitionerId = 'Practitioner/1234';
+const patientIdentity = `${apiUrl}${patientId}`;
+const practitionerIdentity = `${apiUrl}${practitionerId}`;
+const externalPractitionerIdentity = `${apiUrl}test/${practitionerId}`;
+const patientFhirResource = getFhirUser(patientIdentity);
+const practitionerFhirResource = getFhirUser(practitionerIdentity);
+const externalPractitionerFhirResource = getFhirUser(externalPractitionerIdentity);
+const sub = 'test@test.com';
+
+const patientContext: any = {
+    launch_response_patient: patientIdentity,
+};
+const patientFhirUser: any = {
+    fhirUser: patientIdentity,
+};
+const practitionerFhirUser: any = {
+    fhirUser: practitionerIdentity,
+};
+
+const baseAccessNoScopes: any = {
+    ver: 1,
+    jti: 'AT.6a7kncTCpu1X9eo2QhH1z_WLUK4TyV43n_9I6kZNwPY',
+    iss: expectedIss,
+    aud: expectedAud,
+    iat: 1603118138,
+    exp: 1603121738,
+    cid: '0oa8muazKSyk9gP5y5d5',
+    uid: '00u85ozwjjWRd17PB5d5',
+    sub,
+};
 
 const validPatient = {
     resourceType: 'Patient',
@@ -147,7 +140,7 @@ const validPatientObservation = {
         ],
     },
     subject: {
-        reference: patientIdentityWithoutScopes[authZConfig.fhirUserClaimKey],
+        reference: patientIdentity,
         display: 'JONNY',
     },
     effectivePeriod: {
@@ -217,7 +210,7 @@ const validPatientEncounter = {
     participant: [
         {
             individual: {
-                reference: externalPractitionerIdentityWithoutScopes[authZConfig.fhirUserClaimKey],
+                reference: externalPractitionerIdentity,
             },
         },
     ],
@@ -237,6 +230,7 @@ beforeEach(() => {
 afterEach(() => {
     mock.reset();
 });
+
 describe('constructor', () => {
     test('ERROR: Attempt to create a handler to support a new config version', async () => {
         expect(() => {
@@ -252,319 +246,311 @@ describe('constructor', () => {
         }).toThrow(new Error('Authorization configuration version does not match handler version'));
     });
 });
-function addScopeToUserIdentity(partialIdentity: any, accessToken: string) {
-    const identity = clone(partialIdentity);
-    const decoded: any = decode(accessToken);
-    identity.scopes = Array.isArray(decoded!.scp) ? decoded!.scp : decoded!.scp.split(' ');
-    return identity;
+
+function getExpectedUserIdentity(decodedAccessToken: any): any {
+    const expectedUserIdentity = clone(decodedAccessToken);
+    expectedUserIdentity.scopes = getScopes(decodedAccessToken.scp);
+    const usableScopes = expectedUserIdentity.scopes.filter(
+        (scope: string) => scope.startsWith('user/') || scope.startsWith('patient/'),
+    );
+    if (decodedAccessToken.fhirUser && usableScopes.some((scope: string) => scope.startsWith('user/'))) {
+        expectedUserIdentity.fhirUserObject = getFhirUser(decodedAccessToken.fhirUser);
+    }
+    if (
+        decodedAccessToken.launch_response_patient &&
+        usableScopes.some((scope: string) => scope.startsWith('patient/'))
+    ) {
+        expectedUserIdentity.patientLaunchContext = getFhirResource(decodedAccessToken.launch_response_patient, apiUrl);
+    }
+    return expectedUserIdentity;
 }
 
-describe('verifyAccessToken; scopes are in an array', () => {
-    const arrayScopesCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
-        ['aud_failure', { accessToken: audStringWrongAccess, operation: 'create', resourceType: 'Patient' }, false],
-        ['iss_failure', { accessToken: issWrongAccess, operation: 'create', resourceType: 'Patient' }, false],
-        ['no_fhir_scopes', { accessToken: noFHIRScopesAccess, operation: 'create', resourceType: 'Patient' }, false],
-        ['launch_scope', { accessToken: launchAccess, operation: 'create', resourceType: 'Patient' }, false],
-        ['launch/patient', { accessToken: launchPatientAccess, operation: 'search-system' }, true],
+describe('verifyAccessToken', () => {
+    const cases: (string | boolean | VerifyAccessTokenRequest | any)[][] = [
         [
-            'launch/encounter',
-            { accessToken: launchEncounterAccess, operation: 'read', resourceType: 'Patient', id: '123' },
-            true,
-        ],
-        [
-            'manyRead_Write',
-            { accessToken: manyReadAccess, operation: 'update', resourceType: 'Patient', id: '12' },
+            'aud_failure',
+            { accessToken: 'fake', operation: 'create', resourceType: 'Patient' },
+            { ...baseAccessNoScopes, aud: 'fake', scp: ['patient/*.*'], ...patientContext },
             false,
         ],
         [
-            'manyRead_Read',
-            { accessToken: manyReadAccess, operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
-            true,
-        ],
-        [
-            'manyRead_search',
-            { accessToken: manyReadAccess, operation: 'search-type', resourceType: 'Observation' },
-            true,
-        ],
-        [
-            'manyWrite_Read',
-            { accessToken: manyWriteAccess, operation: 'read', resourceType: 'Patient', id: '12' },
+            'aud_not_in_array',
+            { accessToken: 'fake', operation: 'search-type', resourceType: 'Observation' },
+            { ...baseAccessNoScopes, aud: ['aud1', 'aud2'], scp: ['patient/*.read'], ...patientContext },
             false,
         ],
         [
-            'manyWrite_Write_transaction. system scope does have access to transaction',
-            { accessToken: manyWriteAccess, operation: 'transaction' },
+            'aud_in_array',
+            { accessToken: 'fake', operation: 'search-type', resourceType: 'Observation' },
+            { ...baseAccessNoScopes, aud: ['aud1', expectedAud, 'aud2'], scp: ['patient/*.read'], ...patientContext },
             true,
         ],
         [
-            'manyRead_withSpaceScope',
-            {
-                accessToken: manyReadAccessScopeSpaces,
-                operation: 'vread',
-                resourceType: 'Observation',
-                id: '1',
-                vid: '1',
-            },
+            'iss_failure',
+            { accessToken: 'fake', operation: 'create', resourceType: 'Patient' },
+            { ...baseAccessNoScopes, iss: 'fake', scp: ['patient/*.*'], ...patientContext },
             false,
         ],
         [
-            'manyWrite_Write_create',
-            { accessToken: manyWriteAccess, operation: 'create', resourceType: 'Patient' },
+            'no_fhir_scopes',
+            { accessToken: 'fake', operation: 'create', resourceType: 'Patient' },
+            baseAccessNoScopes,
+            false,
+        ],
+        [
+            'launch_scope_create',
+            { accessToken: 'fake', operation: 'create', resourceType: 'Patient' },
+            { ...baseAccessNoScopes, scp: ['launch'] },
+            false,
+        ],
+        [
+            'launch/patient_search',
+            { accessToken: 'fake', operation: 'search-system' },
+            { ...baseAccessNoScopes, scp: ['launch/patient'] },
+            false,
+        ],
+        [
+            'launch/encounter_read',
+            { accessToken: 'fake', operation: 'read', resourceType: 'Patient', id: patientId },
+            { ...baseAccessNoScopes, scp: ['launch/encounter'] },
+            false,
+        ],
+        [
+            'patient_manyRead_Write',
+            { accessToken: 'fake', operation: 'update', resourceType: 'Patient', id: patientId },
+            { ...baseAccessNoScopes, scp: ['patient/*.read'], ...patientContext },
+            false,
+        ],
+        [
+            'patient_manyRead_Read',
+            { accessToken: 'fake', operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
+            { ...baseAccessNoScopes, scp: ['patient/*.read'], ...patientContext },
             true,
         ],
-        ['sys_read', { accessToken: allSysAccess, operation: 'read', resourceType: 'Patient', id: '12' }, true],
-        ['sys_transaction', { accessToken: allSysAccess, operation: 'transaction' }, true],
-        ['sys_history', { accessToken: allSysAccess, operation: 'history-system' }, true],
-        ['sys_fakeType', { accessToken: allSysAccess, operation: 'create', resourceType: 'Fake' }, true],
+        [
+            'patient_ObservationRead_Read',
+            { accessToken: 'fake', operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
+            { ...baseAccessNoScopes, scp: 'patient/Observation.read', ...patientContext },
+            true,
+        ],
+        [
+            'patient_manyRead_search',
+            { accessToken: 'fake', operation: 'search-type', resourceType: 'Observation' },
+            { ...baseAccessNoScopes, scp: 'patient/*.read', ...patientContext },
+            true,
+        ],
+        [
+            'patient_manyWrite_Read',
+            { accessToken: 'fake', operation: 'read', resourceType: 'Patient', id: patientId },
+            { ...baseAccessNoScopes, scp: 'patient/*.write', ...patientContext },
+            false,
+        ],
+        [
+            'patient_PatientWrite_create',
+            { accessToken: 'fake', operation: 'create', resourceType: 'Patient' },
+            { ...baseAccessNoScopes, scp: 'patient/Patient.write', ...patientContext },
+            true,
+        ],
+        [
+            'patient_manyWrite_no_context',
+            { accessToken: 'fake', operation: 'create', resourceType: 'Patient' },
+            { ...baseAccessNoScopes, scp: 'patient/*.*' },
+            false,
+        ],
+        [
+            'user_manyRead_Write',
+            { accessToken: 'fake', operation: 'update', resourceType: 'Patient', id: patientId },
+            { ...baseAccessNoScopes, scp: ['user/*.read'], ...patientFhirUser },
+            false,
+        ],
+        [
+            'user_manyRead_Read',
+            { accessToken: 'fake', operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
+            { ...baseAccessNoScopes, scp: ['user/*.read'], ...patientFhirUser },
+            true,
+        ],
+        [
+            'user_ObservationRead_Read',
+            { accessToken: 'fake', operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
+            { ...baseAccessNoScopes, scp: 'user/Observation.read', ...patientFhirUser },
+            true,
+        ],
+        [
+            'user_manyRead_search',
+            { accessToken: 'fake', operation: 'search-type', resourceType: 'Observation' },
+            { ...baseAccessNoScopes, scp: 'user/*.read', ...patientFhirUser },
+            true,
+        ],
+        [
+            'user_manyWrite_Read',
+            { accessToken: 'fake', operation: 'read', resourceType: 'Patient', id: patientId },
+            { ...baseAccessNoScopes, scp: 'user/*.write', ...patientFhirUser },
+            false,
+        ],
+        [
+            'user_PatientWrite_create',
+            { accessToken: 'fake', operation: 'create', resourceType: 'Patient' },
+            { ...baseAccessNoScopes, scp: 'user/Patient.write', ...patientFhirUser },
+            true,
+        ],
+        [
+            'user_manyWrite_no_context',
+            { accessToken: 'fake', operation: 'create', resourceType: 'Patient' },
+            { ...baseAccessNoScopes, scp: 'user/*.*' },
+            false,
+        ],
+        [
+            'user&patient_manyWrite_Read',
+            { accessToken: 'fake', operation: 'read', resourceType: 'Patient', id: patientId },
+            { ...baseAccessNoScopes, scp: 'user/*.write patient/*.write', ...patientFhirUser, ...patientContext },
+            false,
+        ],
+        [
+            'user&patient_PatientWrite_create',
+            { accessToken: 'fake', operation: 'create', resourceType: 'Patient' },
+            { ...baseAccessNoScopes, scp: 'user/Patient.write patient/*.write', ...patientFhirUser, ...patientContext },
+            true,
+        ],
+        [
+            'user&patient_manyWrite_no context or fhirUser',
+            { accessToken: 'fake', operation: 'create', resourceType: 'Patient' },
+            { ...baseAccessNoScopes, scp: 'user/*.*  patient/*.write' },
+            false,
+        ],
     ];
 
     const authZHandler: SMARTHandler = new SMARTHandler(authZConfig, apiUrl, '4.0.1');
-    test.each(arrayScopesCases)('CASE: %p', (_firstArg, request, isValid) => {
-        mock.onGet(authZConfig.userInfoEndpoint).reply(200, patientIdentityWithoutScopes);
+    test.each(cases)('CASE: %p', (_firstArg, request, decodedAccessToken, isValid) => {
+        mock.onGet(authZConfig.userInfoEndpoint).reply(200, decodedAccessToken);
+        const { decode } = jwt as jest.Mocked<typeof import('jsonwebtoken')>;
+        decode.mockReturnValue(<{ [key: string]: any }>decodedAccessToken);
         if (!isValid) {
             return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).rejects.toThrowError(
                 UnauthorizedError,
             );
         }
-        const identity = addScopeToUserIdentity(
-            patientIdentityWithoutScopes,
-            (<VerifyAccessTokenRequest>request).accessToken,
+        const expectedUserIdentity = getExpectedUserIdentity(decodedAccessToken);
+        return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toMatchObject(
+            expectedUserIdentity,
         );
-        return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toEqual(identity);
     });
 });
 
 describe('verifyAccessToken; System level export requests', () => {
-    const arrayScopesCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
+    const arrayScopesCases: (string | boolean | VerifyAccessTokenRequest | any)[][] = [
         [
             'Read and Write Access: initiate-export',
             {
-                accessToken: practitionerUserAllAccess,
+                accessToken: 'fake',
                 operation: 'read',
                 resourceType: '',
                 bulkDataAuth: { exportType: 'system', operation: 'initiate-export' },
             },
+            { ...baseAccessNoScopes, scp: ['user/*.*', 'patient/*.write'], ...practitionerFhirUser },
             true,
         ],
         [
             'Read Access: initiate-export',
             {
-                accessToken: practitionerUserReadAccess,
+                accessToken: 'fake',
                 operation: 'read',
                 resourceType: '',
                 bulkDataAuth: { exportType: 'system', operation: 'initiate-export' },
             },
+            { ...baseAccessNoScopes, scp: ['user/*.read', 'patient/*.*'], ...practitionerFhirUser },
             true,
         ],
         [
             'Read and Write Access: get-status-export',
             {
-                accessToken: practitionerUserAllAccess,
+                accessToken: 'fake',
                 operation: 'read',
                 resourceType: '',
                 bulkDataAuth: { exportType: 'system', operation: 'get-status-export' },
             },
+            { ...baseAccessNoScopes, scp: ['user/*.*'], ...practitionerFhirUser },
             true,
         ],
         [
             'Read and Write Access: cancel-export',
             {
-                accessToken: practitionerUserAllAccess,
+                accessToken: 'fake',
                 operation: 'read',
                 resourceType: '',
                 bulkDataAuth: { exportType: 'system', operation: 'cancel-export' },
             },
+            { ...baseAccessNoScopes, scp: ['user/*.*'], ...practitionerFhirUser },
             true,
         ],
         [
             'No User read access: initiate-export',
             {
-                accessToken: manyReadAccess,
+                accessToken: 'fake',
                 operation: 'read',
                 resourceType: '',
                 bulkDataAuth: { exportType: 'system', operation: 'cancel-export' },
             },
+            { ...baseAccessNoScopes, scp: ['user/*.write'], ...practitionerFhirUser },
+            false,
+        ],
+        [
+            'No User access; Patient only: initiate-export',
+            {
+                accessToken: 'fake',
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'cancel-export' },
+            },
+            { ...baseAccessNoScopes, scp: ['patient/*.*'], ...patientContext },
             false,
         ],
     ];
 
     const authZHandler: SMARTHandler = new SMARTHandler(authZConfig, apiUrl, '4.0.1');
-    test.each(arrayScopesCases)('CASE: %p', (_firstArg, request, isValid) => {
-        mock.onGet(authZConfig.userInfoEndpoint).reply(200, practitionerIdentityWithoutScopes);
+    test.each(arrayScopesCases)('CASE: %p', (_firstArg, request, decodedAccessToken, isValid) => {
+        mock.onGet(authZConfig.userInfoEndpoint).reply(200, decodedAccessToken);
+        const { decode } = jwt as jest.Mocked<typeof import('jsonwebtoken')>;
+        decode.mockReturnValue(<{ [key: string]: any }>decodedAccessToken);
         if (!isValid) {
             return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).rejects.toThrowError(
                 UnauthorizedError,
             );
         }
-        const identity = addScopeToUserIdentity(
-            practitionerIdentityWithoutScopes,
-            (<VerifyAccessTokenRequest>request).accessToken,
+        const expectedUserIdentity = getExpectedUserIdentity(decodedAccessToken);
+        expectedUserIdentity.scp = decodedAccessToken.scp;
+        return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toMatchObject(
+            expectedUserIdentity,
         );
-        return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toEqual(identity);
     });
 });
-
-describe('verifyAccessToken; scopes are space delimited', () => {
-    const spaceScopesCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
-        [
-            'manyRead_Write',
-            { accessToken: manyReadAccessScopeSpaces, operation: 'update', resourceType: 'Patient', id: '12' },
-            false,
-        ],
-        [
-            'manyRead_Read',
-            {
-                accessToken: manyReadAccessScopeSpaces,
-                operation: 'vread',
-                resourceType: 'Observation',
-                id: '1',
-                vid: '1',
-            },
-            true,
-        ],
-        [
-            'manyRead_search',
-            { accessToken: manyReadAccessScopeSpaces, operation: 'search-type', resourceType: 'Observation' },
-            true,
-        ],
-        [
-            'manyRead_launchScopeOnly',
-            {
-                accessToken: manyReadAccessScopeSpacesJustLaunch,
-                operation: 'read',
-                resourceType: 'Observation',
-                id: '1',
-            },
-            true,
-        ],
-        [
-            'manyRead_withArrayScope',
-            { accessToken: manyReadAccess, operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
-            false,
-        ],
-    ];
-
-    const authZHandler: SMARTHandler = new SMARTHandler(
-        {
-            ...authZConfig,
-            scopeValueType: 'space',
-        },
-        apiUrl,
-        '4.0.1',
-    );
-
-    test.each(spaceScopesCases)('CASE: %p', async (_firstArg, request, isValid) => {
-        mock.onGet(authZConfig.userInfoEndpoint).reply(200, patientIdentityWithoutScopes);
-        if (!isValid) {
-            await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).rejects.toThrowError(
-                UnauthorizedError,
-            );
-        } else {
-            const identity = addScopeToUserIdentity(
-                patientIdentityWithoutScopes,
-                (<VerifyAccessTokenRequest>request).accessToken,
-            );
-            await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toEqual(identity);
-        }
-    });
-});
-
-describe('verifyAccessToken; aud is in an array', () => {
-    const arrayAUDCases: (string | boolean | VerifyAccessTokenRequest)[][] = [
-        [
-            'aud_not_in_array',
-            { accessToken: audArrayWrongAccess, operation: 'search-type', resourceType: 'Observation' },
-            false,
-        ],
-        [
-            'aud_in_array',
-            { accessToken: audArrayValidAccess, operation: 'search-type', resourceType: 'Observation' },
-            true,
-        ],
-    ];
-
-    const authZHandler: SMARTHandler = new SMARTHandler(
-        {
-            ...authZConfig,
-            scopeValueType: 'array',
-        },
-        apiUrl,
-        '4.0.1',
-    );
-
-    test.each(arrayAUDCases)('CASE: %p', async (_firstArg, request, isValid) => {
-        mock.onGet(authZConfig.userInfoEndpoint).reply(200, patientIdentityWithoutScopes);
-        if (!isValid) {
-            await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).rejects.toThrowError(
-                UnauthorizedError,
-            );
-        } else {
-            const identity = addScopeToUserIdentity(
-                patientIdentityWithoutScopes,
-                (<VerifyAccessTokenRequest>request).accessToken,
-            );
-            await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toEqual(identity);
-        }
-    });
-});
-
 describe("verifyAccessToken; AuthZ's userInfo interactions", () => {
+    const decoded = {
+        ...baseAccessNoScopes,
+        scp: ['fhirUser', 'user/Patient.write', 'patient/*.*'],
+        ...patientContext,
+        ...patientFhirUser,
+    };
     const apiCases: (string | boolean | VerifyAccessTokenRequest | number | any)[][] = [
-        [
-            '200; success',
-            { accessToken: manyReadAccess, operation: 'search-type', resourceType: 'Observation' },
-            200,
-            patientIdentityWithoutScopes,
-            true,
-        ],
-        [
-            '202; success',
-            { accessToken: manyWriteAccess, operation: 'create', resourceType: 'Patient' },
-            202,
-            patientIdentityWithoutScopes,
-            true,
-        ],
-        [
-            '4XX; failure',
-            { accessToken: manyWriteAccess, operation: 'create', resourceType: 'Patient' },
-            403,
-            {},
-            false,
-        ],
-        [
-            '5XX; failure',
-            { accessToken: manyWriteAccess, operation: 'create', resourceType: 'Patient' },
-            500,
-            {},
-            false,
-        ],
-        [
-            'Cannot find claim',
-            { accessToken: allSysAccess, operation: 'read', resourceType: 'Patient', id: '12' },
-            200,
-            { stuff: '1234' },
-            false,
-        ],
-        [
-            'Claim regex does not match',
-            { accessToken: allSysAccess, operation: 'read', resourceType: 'Patient', id: '12' },
-            200,
-            { [authZConfig.fhirUserClaimKey]: '1234' },
-            false,
-        ],
+        ['200; success', { accessToken: 'fake', operation: 'create', resourceType: 'Patient' }, 200, decoded, true],
+        ['202; success', { accessToken: 'fake', operation: 'create', resourceType: 'Patient' }, 202, decoded, true],
+        ['4XX; failure', { accessToken: 'fake', operation: 'create', resourceType: 'Patient' }, 403, decoded, false],
+        ['5XX; failure', { accessToken: 'fake', operation: 'create', resourceType: 'Patient' }, 500, decoded, false],
     ];
 
     const authZHandler: SMARTHandler = new SMARTHandler(authZConfig, apiUrl, '4.0.1');
-    test.each(apiCases)('CASE: %p', async (_firstArg, request, authRespCode, authRespBody, isValid) => {
-        mock.onGet(authZConfig.userInfoEndpoint).reply(<number>authRespCode, authRespBody);
+    test.each(apiCases)('CASE: %p', async (_firstArg, request, authRespCode, decodedAccessToken, isValid) => {
+        mock.onGet(authZConfig.userInfoEndpoint).reply(<number>authRespCode, decodedAccessToken);
+        const { decode } = jwt as jest.Mocked<typeof import('jsonwebtoken')>;
+        decode.mockReturnValue(<{ [key: string]: any }>decodedAccessToken);
         if (!isValid) {
-            await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).rejects.toThrowError(
+            return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).rejects.toThrowError(
                 UnauthorizedError,
             );
-        } else {
-            const identity = addScopeToUserIdentity(authRespBody, (<VerifyAccessTokenRequest>request).accessToken);
-            await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toEqual(identity);
         }
+        const expectedUserIdentity = getExpectedUserIdentity(decodedAccessToken);
+        return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toMatchObject(
+            expectedUserIdentity,
+        );
     });
     test('CASE: network error', async () => {
         mock.onGet(authZConfig.userInfoEndpoint).networkError();
@@ -627,9 +613,14 @@ describe('authorizeAndFilterReadResponse', () => {
     };
     const cases: (string | ReadResponseAuthorizedRequest | boolean | any)[][] = [
         [
-            'READ: Patient able to read own record',
+            'READ: patient & user scope; Patient able to read own record',
             {
-                userIdentity: patientIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read', 'patient/*.read'],
+                    fhirUserObject: getFhirUser(`${apiUrl}Patient/345`),
+                    patientLaunchContext: patientFhirResource,
+                },
                 operation: 'read',
                 readResponse: validPatient,
             },
@@ -637,9 +628,13 @@ describe('authorizeAndFilterReadResponse', () => {
             validPatient,
         ],
         [
-            'READ: Patient able to vread own Observation (uses absolute url)',
+            'READ: patient scope; Patient able to vread own Observation (uses absolute url)',
             {
-                userIdentity: patientIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['patient/*.read'],
+                    patientLaunchContext: patientFhirResource,
+                },
                 operation: 'vread',
                 readResponse: validPatientObservation,
             },
@@ -647,9 +642,13 @@ describe('authorizeAndFilterReadResponse', () => {
             validPatientObservation,
         ],
         [
-            'READ: Patient able to vread own Encounter (uses short-reference)',
+            'READ: user scope; Patient able to vread own Encounter (uses short-reference)',
             {
-                userIdentity: patientIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read'],
+                    fhirUserObject: patientFhirResource,
+                },
                 operation: 'read',
                 readResponse: validPatientEncounter,
             },
@@ -659,7 +658,12 @@ describe('authorizeAndFilterReadResponse', () => {
         [
             'READ: Patient unable to vread non-owned Patient record',
             {
-                userIdentity: patientIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read', 'patient/*.read'],
+                    fhirUserObject: patientFhirResource,
+                    patientLaunchContext: patientFhirResource,
+                },
                 operation: 'vread',
                 readResponse: { ...validPatient, id: 'not-yours' },
             },
@@ -669,7 +673,12 @@ describe('authorizeAndFilterReadResponse', () => {
         [
             'READ: Patient unable to read non-direct Observation',
             {
-                userIdentity: patientIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read', 'patient/*.read'],
+                    fhirUserObject: patientFhirResource,
+                    patientLaunchContext: patientFhirResource,
+                },
                 operation: 'read',
                 readResponse: { ...validPatientObservation, subject: 'not-you' },
             },
@@ -679,7 +688,11 @@ describe('authorizeAndFilterReadResponse', () => {
         [
             'READ: Practitioner able to read Encounter',
             {
-                userIdentity: practitionerIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read'],
+                    fhirUserObject: practitionerFhirResource,
+                },
                 operation: 'read',
                 readResponse: validPatientEncounter,
             },
@@ -689,7 +702,11 @@ describe('authorizeAndFilterReadResponse', () => {
         [
             'READ: Practitioner able to read unrelated Observation',
             {
-                userIdentity: practitionerIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read'],
+                    fhirUserObject: practitionerFhirResource,
+                },
                 operation: 'read',
                 readResponse: validPatientObservation,
             },
@@ -699,7 +716,11 @@ describe('authorizeAndFilterReadResponse', () => {
         [
             'READ: external Practitioner able to read Encounter',
             {
-                userIdentity: externalPractitionerIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read'],
+                    fhirUserObject: externalPractitionerFhirResource,
+                },
                 operation: 'read',
                 readResponse: validPatientEncounter,
             },
@@ -709,7 +730,11 @@ describe('authorizeAndFilterReadResponse', () => {
         [
             'READ: external Practitioner unable to read Observation',
             {
-                userIdentity: externalPractitionerIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read'],
+                    fhirUserObject: externalPractitionerFhirResource,
+                },
                 operation: 'read',
                 readResponse: validPatientObservation,
             },
@@ -719,7 +744,12 @@ describe('authorizeAndFilterReadResponse', () => {
         [
             'SEARCH: Patient able to search for empty result',
             {
-                userIdentity: patientIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read', 'patient/*.read'],
+                    fhirUserObject: patientFhirResource,
+                    patientLaunchContext: patientFhirResource,
+                },
                 operation: 'search-system',
                 readResponse: emptySearchResult,
             },
@@ -727,9 +757,13 @@ describe('authorizeAndFilterReadResponse', () => {
             emptySearchResult,
         ],
         [
-            'SEARCH: Patient able to search for own Observation & Patient record',
+            'SEARCH: patient scope; Patient able to search for own Observation & Patient record',
             {
-                userIdentity: patientIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['patient/*.read'],
+                    patientLaunchContext: patientFhirResource,
+                },
                 operation: 'search-type',
                 readResponse: searchAllEntitiesMatch,
             },
@@ -737,9 +771,13 @@ describe('authorizeAndFilterReadResponse', () => {
             searchAllEntitiesMatch,
         ],
         [
-            "SEARCH: Patient's history results are filtered to only contain valid entries",
+            "SEARCH: user scope; Patient's history results are filtered to only contain valid entries",
             {
-                userIdentity: patientIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read', 'fhirUser'],
+                    fhirUserObject: patientFhirResource,
+                },
                 operation: 'history-type',
                 readResponse: searchSomeEntitiesMatch,
             },
@@ -747,9 +785,14 @@ describe('authorizeAndFilterReadResponse', () => {
             searchAllEntitiesMatch,
         ],
         [
-            "SEARCH: Patient's history results are all filtered out",
+            "SEARCH: both scopes; Patient's history results are all filtered out",
             {
-                userIdentity: patientIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read', 'patient/*.read'],
+                    fhirUserObject: patientFhirResource,
+                    patientLaunchContext: patientFhirResource,
+                },
                 operation: 'history-system',
                 readResponse: searchNoEntitiesMatch,
             },
@@ -757,9 +800,13 @@ describe('authorizeAndFilterReadResponse', () => {
             emptySearchResult,
         ],
         [
-            'SEARCH: external Practitioner able to search and filtered to just the encounter',
+            'SEARCH: user scope; external Practitioner able to search and filtered to just the encounter',
             {
-                userIdentity: externalPractitionerIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read'],
+                    fhirUserObject: externalPractitionerFhirResource,
+                },
                 operation: 'search-type',
                 readResponse: searchAllEntitiesMatch,
             },
@@ -767,9 +814,13 @@ describe('authorizeAndFilterReadResponse', () => {
             { ...emptySearchResult, entry: [createEntry(validPatientEncounter)] },
         ],
         [
-            'SEARCH: Practitioner able to search and get ALL results',
+            'SEARCH: user scope; Practitioner able to search and get ALL results',
             {
-                userIdentity: practitionerIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.read'],
+                    fhirUserObject: practitionerFhirResource,
+                },
                 operation: 'search-type',
                 readResponse: searchAllEntitiesMatch,
             },
@@ -794,31 +845,43 @@ describe('authorizeAndFilterReadResponse', () => {
 describe('isWriteRequestAuthorized', () => {
     const cases: (string | WriteRequestAuthorizedRequest | boolean)[][] = [
         [
-            'Patient unable to write own Encounter',
+            'CREATE: patient scope; Patient able to write own Encounter',
             {
-                userIdentity: patientIdentityWithoutScopes,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['patient/*.write'],
+                    patientLaunchContext: patientFhirResource,
+                },
                 operation: 'create',
                 resourceBody: validPatientEncounter,
             },
-            false,
+            true,
         ],
         [
-            'Practitioner able to write Patient',
+            'UPDATE: user scope; Practitioner able to write Patient',
             {
-                userIdentity: practitionerIdentityWithoutScopes,
-                operation: 'vread',
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.write'],
+                    fhirUserObject: practitionerFhirResource,
+                },
+                operation: 'update',
                 resourceBody: validPatient,
             },
             true,
         ],
         [
-            'External practitioner unable to write Patient',
+            'PATCH: user scope; External practitioner able to write Patient',
             {
-                userIdentity: externalPractitionerIdentityWithoutScopes,
-                operation: 'vread',
-                resourceBody: validPatient,
+                userIdentity: {
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.write'],
+                    fhirUserObject: externalPractitionerFhirResource,
+                },
+                operation: 'patch',
+                resourceBody: { ...validPatient, generalPractitioner: { reference: externalPractitionerIdentity } },
             },
-            false,
+            true,
         ],
     ];
 
@@ -844,9 +907,11 @@ describe('isAccessBulkDataJobAllowed', () => {
             'userIdentity and jobOwnerId match',
             {
                 userIdentity: {
-                    sub: 'abc',
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.*'],
+                    fhirUserObject: practitionerFhirResource,
                 },
-                jobOwnerId: 'abc',
+                jobOwnerId: sub,
             },
             true,
         ],
@@ -854,7 +919,9 @@ describe('isAccessBulkDataJobAllowed', () => {
             'userIdentity and jobOwnerId does NOT match',
             {
                 userIdentity: {
-                    sub: 'abc',
+                    ...baseAccessNoScopes,
+                    scopes: ['user/*.*'],
+                    fhirUserObject: practitionerFhirResource,
                 },
                 jobOwnerId: 'xyz',
             },
@@ -884,36 +951,70 @@ describe('isBundleRequestAuthorized', () => {
 
     const cases: any[][] = [
         [
-            'practitioner with user scope to create observation: no error',
-            practitionerIdentityWithoutScopes,
-            ['user/Observation.write'],
+            'practitioner with user scope: no error',
+            {
+                ...baseAccessNoScopes,
+                scopes: ['user/Observation.write', 'user/*.read', 'fhirUser'],
+                fhirUserObject: practitionerFhirResource,
+            },
             true,
         ],
         [
-            'practitioner without user scope to create observation: Unauthorized Error',
-            practitionerIdentityWithoutScopes,
-            ['user/Patient.write'],
+            'patient with patient scope: no error',
+            {
+                ...baseAccessNoScopes,
+                scopes: ['patient/*.*', 'profile'],
+                patientLaunchContext: patientFhirResource,
+            },
+            true,
+        ],
+        [
+            'practitioner with patient&user scope: no error',
+            {
+                ...baseAccessNoScopes,
+                scopes: ['user/Observation.write', 'patient/Patient.*', 'openid'],
+                fhirUserObject: practitionerFhirResource,
+                patientLaunchContext: patientFhirResource,
+            },
+            true,
+        ],
+        [
+            'patient with user scope to create observation but no read perms: Unauthorized Error',
+            {
+                ...baseAccessNoScopes,
+                scopes: ['user/Observation.write'],
+                fhirUserObject: patientFhirResource,
+            },
             false,
         ],
         [
-            'patient with user scope to create observation but is not in typesWithWriteAccess: Unauthorized Error',
-            patientIdentityWithoutScopes,
-            ['user/Observation.write'],
+            'practitioner with patient scope but no write perms: Unauthorized Error',
+            {
+                ...baseAccessNoScopes,
+                scopes: ['patient/Patient.read'],
+                fhirUserObject: practitionerFhirResource,
+                patientLaunchContext: patientFhirResource,
+            },
             false,
         ],
     ];
-    test.each(cases)('CASE: %p', async (_firstArg, baseIdentity, scopes, isAuthorized) => {
-        const userIdentity = clone(baseIdentity);
-        userIdentity.scopes = scopes;
+    test.each(cases)('CASE: %p', async (_firstArg, userIdentity, isAuthorized) => {
         const request: AuthorizationBundleRequest = {
             userIdentity,
             requests: [
                 {
                     operation: 'create',
-                    resource: {},
+                    resource: validPatientObservation,
                     fullUrl: '',
                     resourceType: 'Observation',
                     id: '160265f7-e8c2-45ca-a1bc-317399e23549',
+                },
+                {
+                    operation: 'read',
+                    resource: patientIdentity,
+                    fullUrl: patientIdentity,
+                    resourceType: 'Patient',
+                    id: '160265f7-e8c2-45ca-a1bc-317399e23548',
                 },
             ],
         };
@@ -926,35 +1027,6 @@ describe('isBundleRequestAuthorized', () => {
             await expect(authZHandler.isBundleRequestAuthorized(request)).resolves.not.toThrow();
         }
     });
-
-    test('Bundle request with first Bundle entry passing and second Bundle entry failing', async () => {
-        const userIdentity = clone(practitionerIdentityWithoutScopes);
-        // Requester has permission to write Observation but no permission to read Observation
-        userIdentity.scopes = ['user/Observation.write'];
-        const request: AuthorizationBundleRequest = {
-            userIdentity,
-            requests: [
-                {
-                    operation: 'create',
-                    resource: {},
-                    fullUrl: '',
-                    resourceType: 'Observation',
-                    id: '160265f7-e8c2-45ca-a1bc-317399e23549',
-                },
-                {
-                    operation: 'read',
-                    resource: {},
-                    fullUrl: '',
-                    resourceType: 'Observation',
-                    id: 'fcfe413c-c62d-4097-9e31-02ff6ff523ad',
-                },
-            ],
-        };
-
-        await expect(authZHandler.isBundleRequestAuthorized(request)).rejects.toThrowError(
-            new UnauthorizedError('An entry within the Bundle is not authorized'),
-        );
-    });
 });
 
 describe('getAllowedResourceTypesForOperation', () => {
@@ -965,14 +1037,14 @@ describe('getAllowedResourceTypesForOperation', () => {
     const cases: (string | string[])[][] = [
         [
             'search-type operation: read scope: returns [Patient, Observation]',
-            ['user/Patient.read', 'user/Observation.read'],
+            ['user/Patient.read', 'user/Observation.read', 'fhirUser'],
             'search-type',
             ['Patient', 'Observation'],
         ],
         // if there are duplicated scopeResourceType we return an array with the duplicates removed
         [
             'search-type operation: read scope: duplicated Observation scopeResourceType still returns [Patient, Observation]',
-            ['user/Patient.read', 'patient/Observation.read', 'user/Observation.read'],
+            ['launch/patient', 'user/Patient.read', 'patient/Observation.read', 'user/Observation.read', 'launch'],
             'search-type',
             ['Patient', 'Observation'],
         ],
@@ -1006,9 +1078,13 @@ describe('getAllowedResourceTypesForOperation', () => {
 
 describe('getSearchFilterBasedOnIdentity', () => {
     const authZHandler: SMARTHandler = new SMARTHandler(authZConfig, apiUrl, '4.0.1');
-    test('Patient identity', async () => {
+    test('Patient context identity', async () => {
         // BUILD
-        const userIdentity = clone(patientIdentityWithoutScopes);
+        const userIdentity = {
+            ...baseAccessNoScopes,
+            scopes: ['patient/*.*', 'user/*.read', 'fhirUser'],
+            patientLaunchContext: getFhirResource(patientId, apiUrl),
+        };
         const request: GetSearchFilterBasedOnIdentityRequest = {
             userIdentity,
             operation: 'search-type',
@@ -1020,13 +1096,36 @@ describe('getSearchFilterBasedOnIdentity', () => {
                 key: '_reference',
                 logicalOperator: 'OR',
                 comparisonOperator: '==',
-                value: [patientId, `${apiUrl}${patientId}`],
+                value: [patientIdentity, patientId],
+            },
+        ];
+        await expect(authZHandler.getSearchFilterBasedOnIdentity(request)).resolves.toEqual(expectedFilter);
+    });
+    test('User identity', async () => {
+        // BUILD
+        const userIdentity = {
+            ...baseAccessNoScopes,
+            scopes: ['patient/*.*', 'user/*.*', 'fhirUser'],
+            fhirUserObject: patientFhirResource,
+        };
+        const request: GetSearchFilterBasedOnIdentityRequest = {
+            userIdentity,
+            operation: 'search-type',
+        };
+
+        // OPERATE, CHECK
+        const expectedFilter = [
+            {
+                key: '_reference',
+                logicalOperator: 'OR',
+                comparisonOperator: '==',
+                value: [patientIdentity, patientId],
             },
         ];
         await expect(authZHandler.getSearchFilterBasedOnIdentity(request)).resolves.toEqual(expectedFilter);
     });
 
-    test('Patient identity; fhirUser hostname does not match server hostname', async () => {
+    test('User & Patient identity; fhirUser hostname does not match server hostname', async () => {
         // BUILD
         const authZHandlerWithFakeApiUrl: SMARTHandler = new SMARTHandler(
             authZConfig,
@@ -1034,7 +1133,12 @@ describe('getSearchFilterBasedOnIdentity', () => {
             '4.0.1',
         );
 
-        const userIdentity = clone(patientIdentityWithoutScopes);
+        const userIdentity = {
+            ...baseAccessNoScopes,
+            scopes: ['patient/*.*', 'user/*.*', 'fhirUser'],
+            patientLaunchContext: patientFhirResource,
+            fhirUserObject: patientFhirResource,
+        };
         const request: GetSearchFilterBasedOnIdentityRequest = {
             userIdentity,
             operation: 'search-type',
@@ -1046,7 +1150,7 @@ describe('getSearchFilterBasedOnIdentity', () => {
                 key: '_reference',
                 logicalOperator: 'OR',
                 comparisonOperator: '==',
-                value: [`${apiUrl}${patientId}`],
+                value: [patientIdentity, patientIdentity],
             },
         ];
         await expect(authZHandlerWithFakeApiUrl.getSearchFilterBasedOnIdentity(request)).resolves.toEqual(
@@ -1056,7 +1160,11 @@ describe('getSearchFilterBasedOnIdentity', () => {
 
     test('Practitioner identity', async () => {
         // BUILD
-        const userIdentity = clone(practitionerIdentityWithoutScopes);
+        const userIdentity = {
+            ...baseAccessNoScopes,
+            scopes: ['user/*.*', 'fhirUser'],
+            fhirUserObject: practitionerFhirResource,
+        };
         const request: GetSearchFilterBasedOnIdentityRequest = {
             userIdentity,
             operation: 'search-type',

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -12,7 +12,6 @@ import {
     ReadResponseAuthorizedRequest,
     WriteRequestAuthorizedRequest,
     AccessBulkDataJobRequest,
-    KeyValueMap,
     clone,
     BatchReadWriteRequest,
     BASE_R4_RESOURCES,

--- a/src/smartScopeHelper.test.ts
+++ b/src/smartScopeHelper.test.ts
@@ -74,6 +74,25 @@ describe.each(isScopeSufficientCases)('%s: isScopeSufficient', (scopeType: strin
             isScopeSufficient(`${scopeType}/Observation.read`, clonedScopeRule, 'read', undefined, bulkDataAuth),
         ).toEqual(false);
     });
+    test('scope is sufficient to do a search-system', () => {
+        const clonedScopeRule = clone(scopeRule);
+        clonedScopeRule[scopeType].read = ['search-system'];
+
+        expect(isScopeSufficient(`${scopeType}/*.read`, clonedScopeRule, 'search-system')).toEqual(true);
+    });
+    test('scope is sufficient to do a transaction', () => {
+        const clonedScopeRule = clone(scopeRule);
+        clonedScopeRule[scopeType].write = ['transaction'];
+
+        expect(isScopeSufficient(`${scopeType}/*.write`, clonedScopeRule, 'transaction')).toEqual(true);
+    });
+    test('scope is insufficient to do a transaction', () => {
+        const clonedScopeRule = clone(scopeRule);
+        clonedScopeRule[scopeType].read = ['read'];
+        clonedScopeRule[scopeType].write = ['create'];
+
+        expect(isScopeSufficient(`${scopeType}/*.*`, clonedScopeRule, 'transaction')).toEqual(false);
+    });
     test('invalid scope', () => {
         const clonedScopeRule = clone(scopeRule);
         clonedScopeRule[scopeType].read = ['read'];

--- a/src/smartScopeHelper.ts
+++ b/src/smartScopeHelper.ts
@@ -129,7 +129,7 @@ export function isScopeSufficient(
  * - Without the `launch_response_patient` claim the 'patient' scopes cannot be validated
  * - Scopes like profile, launch or fhirUser will be filtered out as well
  */
-export function filterScopes(
+export function filterOutUnusableScope(
     scopes: string[],
     scopeRule: ScopeRule,
     reqOperation: TypeOperation | SystemOperation,

--- a/src/smartScopeHelper.ts
+++ b/src/smartScopeHelper.ts
@@ -1,35 +1,17 @@
 import { BulkDataAuth, SystemOperation, TypeOperation } from 'fhir-works-on-aws-interface';
-import {
-    AccessModifier,
-    ClinicalSmartScope,
-    LaunchSmartScope,
-    LaunchType,
-    ScopeRule,
-    ScopeType,
-    SmartScope,
-} from './smartConfig';
+import { AccessModifier, ClinicalSmartScope, ScopeRule, ScopeType } from './smartConfig';
 
 export const SEARCH_OPERATIONS: (TypeOperation | SystemOperation)[] = [
-    'history-type',
-    'history-instance',
     'search-type',
     'search-system',
+    'history-type',
+    'history-instance',
     'history-system',
 ];
 
-export const CLINICAL_SCOPE_REGEX = /^(?<scopeType>patient|user|system)\/(?<scopeResourceType>[A-Z][a-zA-Z]+|\*)\.(?<accessType>read|write|\*)$/;
+export const CLINICAL_SCOPE_REGEX = /^(?<scopeType>patient|user)\/(?<scopeResourceType>[A-Z][a-zA-Z]+|\*)\.(?<accessType>read|write|\*)$/;
 
-export const LAUNCH_SCOPE_REGEX = /^(?<scopeType>launch)(\/(?<launchType>patient|encounter))?$/;
-
-export function convertScopeToSmartScope(scope: string): SmartScope {
-    const matchLaunchScope = scope.match(LAUNCH_SCOPE_REGEX);
-    if (matchLaunchScope) {
-        const { launchType } = matchLaunchScope.groups!;
-        return {
-            scopeType: 'launch',
-            launchType: <LaunchType>launchType,
-        };
-    }
+export function convertScopeToSmartScope(scope: string): ClinicalSmartScope {
     const matchClinicalScope = scope.match(CLINICAL_SCOPE_REGEX);
     if (matchClinicalScope) {
         const { scopeType, scopeResourceType, accessType } = matchClinicalScope.groups!;
@@ -46,7 +28,7 @@ export function convertScopeToSmartScope(scope: string): SmartScope {
 
 export function getValidOperationsForScopeTypeAndAccessType(
     scopeType: ScopeType,
-    accessType: string,
+    accessType: AccessModifier,
     scopeRule: ScopeRule,
 ): (TypeOperation | SystemOperation)[] {
     let validOperations: (TypeOperation | SystemOperation)[] = [];
@@ -60,52 +42,46 @@ export function getValidOperationsForScopeTypeAndAccessType(
 }
 
 function getValidOperationsForScope(
-    smartScope: SmartScope,
+    smartScope: ClinicalSmartScope,
     scopeRule: ScopeRule,
     reqOperation: TypeOperation | SystemOperation,
     reqResourceType?: string,
 ): (TypeOperation | SystemOperation)[] {
     let validOperations: (TypeOperation | SystemOperation)[] = [];
-    if (smartScope.scopeType === 'launch') {
-        const launchSmartScope = <LaunchSmartScope>smartScope;
-        // TODO: should launch have access to only certain resourceTypes?
-        validOperations = scopeRule.launch[launchSmartScope.launchType ?? 'launch'];
-    } else {
-        const clinicalSmartScope = <ClinicalSmartScope>smartScope;
-        const { scopeType, resourceType, accessType } = clinicalSmartScope;
-        if (reqResourceType) {
-            if (resourceType === '*' || resourceType === reqResourceType) {
-                validOperations = getValidOperationsForScopeTypeAndAccessType(scopeType, accessType, scopeRule);
-            }
-        }
-        // 'search-system' and 'history-system' request operation requires '*' for scopeResourceType
-        else if (['search-system', 'history-system'].includes(reqOperation) && resourceType === '*') {
-            validOperations = getValidOperationsForScopeTypeAndAccessType(scopeType, accessType, scopeRule);
-        } else if (['transaction', 'batch'].includes(reqOperation)) {
+    const { scopeType, resourceType, accessType } = smartScope;
+    if (reqResourceType) {
+        if (resourceType === '*' || resourceType === reqResourceType) {
             validOperations = getValidOperationsForScopeTypeAndAccessType(scopeType, accessType, scopeRule);
         }
     }
+    // 'search-system' and 'history-system' request operation requires '*' for scopeResourceType
+    else if (
+        (['search-system', 'history-system'].includes(reqOperation) && resourceType === '*') ||
+        ['transaction', 'batch'].includes(reqOperation)
+    ) {
+        validOperations = getValidOperationsForScopeTypeAndAccessType(scopeType, accessType, scopeRule);
+    }
+
     return validOperations;
 }
 
-// eslint-disable-next-line class-methods-use-this
-export function getScopes(scopeValueType: 'space' | 'array', scopes: string | string[]): string[] {
-    if (scopeValueType === 'space' && typeof scopes === 'string') {
-        return scopes.split(' ');
-    }
-    if (scopeValueType === 'array' && Array.isArray(scopes)) {
+export function getScopes(scopes: string | string[]): string[] {
+    if (Array.isArray(scopes)) {
         return scopes;
+    }
+    if (typeof scopes === 'string') {
+        return scopes.split(' ');
     }
     return [];
 }
 
 function isSmartScopeSufficientForBulkDataAccess(
     bulkDataAuth: BulkDataAuth,
-    smartScope: SmartScope,
+    smartScope: ClinicalSmartScope,
     scopeRule: ScopeRule,
 ) {
     const bulkDataRequestHasCorrectScope =
-        bulkDataAuth.exportType === 'system' && // As of 12/9/20 we only support System Level export
+        bulkDataAuth.exportType === 'system' && // As of 2021-01-09 we only support System Level export
         smartScope.scopeType === 'user' &&
         smartScope.resourceType === '*' &&
         ['*', 'read'].includes(smartScope.accessType) &&
@@ -118,33 +94,53 @@ function isSmartScopeSufficientForBulkDataAccess(
     );
 }
 
-export function areScopesSufficient(
-    scopes: string[],
-    operation: TypeOperation | SystemOperation,
+export function isScopeSufficient(
+    scope: string,
     scopeRule: ScopeRule,
-    resourceType?: string,
+    reqOperation: TypeOperation | SystemOperation,
+    reqResourceType?: string,
     bulkDataAuth?: BulkDataAuth,
 ): boolean {
-    for (let i = 0; i < scopes.length; i += 1) {
-        const scope = scopes[i];
-        try {
-            const smartScope = convertScopeToSmartScope(scope);
-            if (bulkDataAuth) {
-                if (isSmartScopeSufficientForBulkDataAccess(bulkDataAuth, smartScope, scopeRule)) {
-                    return true;
-                }
-            } else {
-                const validOperations: (TypeOperation | SystemOperation)[] = getValidOperationsForScope(
-                    smartScope,
-                    scopeRule,
-                    operation,
-                    resourceType,
-                );
-                if (validOperations.includes(operation)) return true;
+    try {
+        const smartScope = convertScopeToSmartScope(scope);
+        if (bulkDataAuth) {
+            if (isSmartScopeSufficientForBulkDataAccess(bulkDataAuth, smartScope, scopeRule)) {
+                return true;
             }
-        } catch (e) {
-            // Caused by trying to convert non-SmartScope to SmartScope, for example converting non-SMART scope 'openid'
+        } else {
+            const validOperations: (TypeOperation | SystemOperation)[] = getValidOperationsForScope(
+                smartScope,
+                scopeRule,
+                reqOperation,
+                reqResourceType,
+            );
+            if (validOperations.includes(reqOperation)) return true;
         }
+    } catch (e) {
+        // Caused by trying to convert non-SmartScope to SmartScope, for example converting non-SMART scope 'openid'
     }
+
     return false;
+}
+
+/**
+ * Remove scopes that do not have the required information to be useful or unused scopes. For example:
+ * - Without the `fhirUser` claim the 'user' scopes cannot be validated
+ * - Without the `launch_response_patient` claim the 'patient' scopes cannot be validated
+ * - Scopes like profile, launch or fhirUser will be filtered out as well
+ */
+export function filterScopes(
+    scopes: string[],
+    scopeRule: ScopeRule,
+    reqOperation: TypeOperation | SystemOperation,
+    reqResourceType?: string,
+    bulkDataAuth?: BulkDataAuth,
+    patientContext?: string,
+    fhirUser?: string,
+): string[] {
+    return scopes.filter(
+        (scope: string) =>
+            ((patientContext && scope.startsWith('patient/')) || (fhirUser && scope.startsWith('user/'))) &&
+            isScopeSufficient(scope, scopeRule, reqOperation, reqResourceType, bulkDataAuth),
+    );
 }


### PR DESCRIPTION
## Description of changes:
### smartAuthorizationHelper
- Change `FhirUser` -> `FhirResource` in the future there will be other launch contexts that we will need to support and they aren't really a `user` e.g. `launch/encounter`
### smartConfig
- Remove `launch` & `system` scopes
- Remove `scopeValueType` config option in favor of programmatically determining if the scopes are in array or string format
### smartHandler
- Remove `typesWithWriteAccess` - this was a forced customization if customer do not want to support writes they can specify in the `scopeRules`
- verifyAccessToken: it is now expected to have `fhirUserClaim` only if request has the `user/` scope and to have `launch_response_patient` only if request has `patient/` scope. If the scope is there but is missing the claim we ignore the said scope, since we cannot verify it.
- verifyAccessToken:  `userIdentity` will now also contain `fhirUserObject` & `patientLaunchContext` which are objects of the original `fhirUser` & `launch_patient` claim
- getSearchFilterBasedOnIdentity: add a filter for both `fhirUserObject` & `patientLaunchContext` if present
- isBundleRequestAuthorized: only use scopes that can be used (i.e. filter out user/ or patient/ if missing context)
### smartScopeHelper
- Remove system scope and launch scope
- switch `areScopesSufficient` -> `isScopeSufficient` which gives flexibility to use .filter
### TESTS
- smartHandler.test: was updated to not use a raw access_token and jwt's decode method making it much easier to understand and create new test-cases (this resulted in a lot of changes though)

#### Coverage information
after running `yarn run test-coverage` below are the results:
```sh
-----------------------------|---------|----------|---------|---------|-------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------|---------|----------|---------|---------|-------------------
All files                    |   99.46 |     95.8 |     100 |   99.44 |
 smartAuthorizationHelper.ts |     100 |      100 |     100 |     100 |
 smartHandler.ts             |   99.12 |    94.05 |     100 |   99.08 | 106
 smartScopeHelper.ts         |     100 |    97.67 |     100 |     100 | 58
-----------------------------|---------|----------|---------|---------|-------------------

Test Suites: 4 passed, 4 total
Tests:       178 passed, 178 total
Snapshots:   0 total
Time:        14.759 s
Ran all test suites.
Done in 18.72s.
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
