### PR TITLE
feat!: Allow paths for fhirUser and launch claims

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fhir-works-on-aws-interface": "^9.0.0",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^1.12.1",
-    "lodash": "^4.17.20"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
     "axios": "^0.21.1",
     "fhir-works-on-aws-interface": "^9.0.0",
     "jsonwebtoken": "^8.5.1",
-    "jwks-rsa": "^1.12.1"
+    "jwks-rsa": "^1.12.1",
+    "lodash": "^4.17.20"
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
     "@types/jsonwebtoken": "^8.5.0",
+    "@types/lodash": "^4.14.161",
     "@types/node": "^12",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",

--- a/src/smartConfig.ts
+++ b/src/smartConfig.ts
@@ -76,14 +76,17 @@ export interface SMARTConfig {
      */
     expectedIssValue: string;
     /**
-     * Name of the claim found in the access_token that represents the requestors FHIR Id
+     * Path of the claim found in the access_token that represents the requestors FHIR Id. SMART compliant AuthZ servers should use the `fhirUser` claim, but can use a path if needed.
+     * @example fhirUser
+     * @example ext.addedClaims.fhirUser
      */
-    fhirUserClaimKey: 'fhirUser' | 'profile';
+    fhirUserClaimPath: 'fhirUser' | 'profile' | string;
     /**
-     * Prefix of the claim found in the access_token that represents the requestors launch context. The remaining part of the claim will identify the resource type i.e. `launch_response_patient`
+     * Prefix of the path found in the access_token that represents the requestors launch context. The remaining part of the claim will identify the resource type i.e. `launch_response_patient`
      * @example launch_response_
+     * @example ext.launch_response_
      */
-    launchContextKeyPrefix: string;
+    launchContextPathPrefix: string;
     /**
      * Json Web Key Set endpoint used to get the key for verifying access_token
      */

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -46,8 +46,8 @@ const baseAuthZConfig = (): SMARTConfig => ({
     scopeRule: scopeRule(),
     expectedAudValue: expectedAud,
     expectedIssValue: expectedIss,
-    fhirUserClaimKey: 'fhirUser',
-    launchContextKeyPrefix: 'launch_response_',
+    fhirUserClaimPath: 'fhirUser',
+    launchContextPathPrefix: 'ext.launch_response_',
     jwksEndpoint: `${expectedIss}/jwks`,
 });
 const apiUrl = 'https://fhir.server.com/dev';
@@ -63,7 +63,7 @@ const externalPractitionerFhirResource = getFhirUser(externalPractitionerIdentit
 const sub = 'test@test.com';
 
 const patientContext: any = {
-    launch_response_patient: patientIdentity,
+    ext: { launch_response_patient: patientIdentity },
 };
 const patientFhirUser: any = {
     fhirUser: patientIdentity,
@@ -240,10 +240,14 @@ function getExpectedUserIdentity(decodedAccessToken: any): any {
         expectedUserIdentity.fhirUserObject = getFhirUser(decodedAccessToken.fhirUser);
     }
     if (
-        decodedAccessToken.launch_response_patient &&
+        decodedAccessToken.ext &&
+        decodedAccessToken.ext.launch_response_patient &&
         usableScopes.some((scope: string) => scope.startsWith('patient/'))
     ) {
-        expectedUserIdentity.patientLaunchContext = getFhirResource(decodedAccessToken.launch_response_patient, apiUrl);
+        expectedUserIdentity.patientLaunchContext = getFhirResource(
+            decodedAccessToken.ext.launch_response_patient,
+            apiUrl,
+        );
     }
     return expectedUserIdentity;
 }

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -240,8 +240,7 @@ function getExpectedUserIdentity(decodedAccessToken: any): any {
         expectedUserIdentity.fhirUserObject = getFhirUser(decodedAccessToken.fhirUser);
     }
     if (
-        decodedAccessToken.ext &&
-        decodedAccessToken.ext.launch_response_patient &&
+        decodedAccessToken?.ext?.launch_response_patient &&
         usableScopes.some((scope: string) => scope.startsWith('patient/'))
     ) {
         expectedUserIdentity.patientLaunchContext = getFhirResource(

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -19,6 +19,7 @@ import {
     SearchFilter,
     clone,
 } from 'fhir-works-on-aws-interface';
+import get from 'lodash/get';
 import { JwksClient } from 'jwks-rsa';
 import { FhirResource, SMARTConfig, UserIdentity } from './smartConfig';
 import {
@@ -93,8 +94,8 @@ export class SMARTHandler implements Authorization {
             this.jwksClient,
         );
 
-        const fhirUserClaim = decodedToken[this.config.fhirUserClaimKey];
-        const patientContextClaim = decodedToken[`${this.config.launchContextKeyPrefix}patient`];
+        const fhirUserClaim = get(decodedToken, this.config.fhirUserClaimPath);
+        const patientContextClaim = get(decodedToken, `${this.config.launchContextPathPrefix}patient`);
 
         // get just the scopes that apply to this request
         const scopes = getScopes(decodedToken[this.config.scopeKey]);
@@ -117,10 +118,10 @@ export class SMARTHandler implements Authorization {
         }
 
         if (request.bulkDataAuth) {
-            if (!decodedToken[this.config.fhirUserClaimKey]) {
+            if (!fhirUserClaim) {
                 throw new UnauthorizedError('User does not have permission for requested operation');
             }
-            const fhirUser = getFhirUser(decodedToken[this.config.fhirUserClaimKey]);
+            const fhirUser = getFhirUser(fhirUserClaim);
             if (fhirUser.hostname !== this.apiUrl || !this.bulkDataAccessTypes.includes(fhirUser.resourceType)) {
                 throw new UnauthorizedError('User does not have permission for requested operation');
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3349,7 +3349,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -647,6 +647,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash@^4.14.161":
+  version "4.14.170"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.170.tgz#0d67711d4bf7f4ca5147e9091b847479b87925d6"
+  integrity sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==
+
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
@@ -3344,7 +3349,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
BREAKING CHANGE

Closing: #39 

Description of changes: 
- allow the fhirUser claim to be nested in the access_token.
- allow the launch context claim to be nested in the access_token.

example below is now valid if `fhirUserClaimPath = "ext.fhirUser"`: 
```json
{
  "ext": {
    "fhirUser": "Patient/1234"
  }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
