### PR TITLE
feat: Add support for `system` scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This resource server supports [SMART's clinical scopes](http://www.hl7.org/fhir/
 - For `user` scopes, there must be a `fhirUser` claim in the access token.
 - The access modifiers `read` and `write` will give permissions as defined in the incoming [SMARTConfig](./src/smartConfig.ts).
 
+// TODO
+
 ### Attribute Based Access Control (ABAC)
 
 This implementation of the SMART on FHIR specification uses attribute based access control. Access to a resource is given if one of the following statements is true:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This resource server supports [SMART's clinical scopes](http://www.hl7.org/fhir/
 - For `user` scopes, there must be a `fhirUser` claim in the access token.
 - The access modifiers `read` and `write` will give permissions as defined in the incoming [SMARTConfig](./src/smartConfig.ts).
 
-// TODO
+The resource server also supports [SMART's Flat FHIR or Bulk Data `system` scope](https://hl7.org/fhir/uv/bulkdata/authorization/index.html#scopes). `system` scopes have the format `system/(:resourceType|*).(read|write|*)`– which conveys the same access scope as the matching user format `user/(:resourceType|*).(read|write|*)`. 
 
 ### Attribute Based Access Control (ABAC)
 
@@ -45,12 +45,13 @@ This implementation of the SMART on FHIR specification uses attribute based acce
 As an example below, the Patient resource is accessible by:
 
 - Admins of the system
+- Requests with the usage of the `system` scope
 - `Patient/example`: via `resourceType` and `id` check
 - `Patient/diffPatient`: since it is referenced in the `link` field
 - `Practitioner/DrBell`: since it is referenced in the `generalPractitioner` field
 
 ```json
-// Example Patient pesource with references
+// Example Patient resource with references
 {
   "resourceType": "Patient",
   "id": "example",

--- a/src/regExpressions.test.ts
+++ b/src/regExpressions.test.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { CLINICAL_SCOPE_REGEX } from './smartScopeHelper';
+import { FHIR_SCOPE_REGEX } from './smartScopeHelper';
 import { FHIR_USER_REGEX, FHIR_RESOURCE_REGEX } from './smartAuthorizationHelper';
 
 describe('CLINICAL_SCOPE_REGEX', () => {
@@ -20,7 +20,7 @@ describe('CLINICAL_SCOPE_REGEX', () => {
     ];
     test.each(testCases)('CASE: %p/%p.%p; expect: matches', async (scopeType, scopeResourceType, accessType) => {
         const expectedStr = `${scopeType}/${scopeResourceType}.${accessType}`;
-        const actualMatch = expectedStr.match(CLINICAL_SCOPE_REGEX);
+        const actualMatch = expectedStr.match(FHIR_SCOPE_REGEX);
         expect(actualMatch).toBeTruthy();
         expect(actualMatch!.groups).toBeTruthy();
         expect(actualMatch!.groups!.scopeType).toEqual(scopeType);
@@ -43,7 +43,7 @@ describe('CLINICAL_SCOPE_REGEX', () => {
         ['system'],
     ];
     test.each(uniqueTestCases)('CASE: %p; expect: no match', async scope => {
-        const actualMatch = scope.match(CLINICAL_SCOPE_REGEX);
+        const actualMatch = scope.match(FHIR_SCOPE_REGEX);
         expect(actualMatch).toBeFalsy();
     });
 });

--- a/src/regExpressions.test.ts
+++ b/src/regExpressions.test.ts
@@ -15,6 +15,8 @@ describe('CLINICAL_SCOPE_REGEX', () => {
         ['patient', 'Observation', 'read'],
         ['patient', 'FakeResource', 'write'],
         ['patient', '*', 'write'],
+        ['system', '*', 'write'],
+        ['system', 'Patient', 'read'],
     ];
     test.each(testCases)('CASE: %p/%p.%p; expect: matches', async (scopeType, scopeResourceType, accessType) => {
         const expectedStr = `${scopeType}/${scopeResourceType}.${accessType}`;
@@ -38,7 +40,7 @@ describe('CLINICAL_SCOPE_REGEX', () => {
         ['/Patient.read'],
         ['patient/.read'],
         ['patient/Patient.'],
-        ['system/Patient.read'],
+        ['system'],
     ];
     test.each(uniqueTestCases)('CASE: %p; expect: no match', async scope => {
         const actualMatch = scope.match(CLINICAL_SCOPE_REGEX);

--- a/src/smartConfig.ts
+++ b/src/smartConfig.ts
@@ -4,7 +4,7 @@
  */
 import { KeyValueMap } from 'fhir-works-on-aws-interface';
 
-export type ScopeType = 'patient' | 'user';
+export type ScopeType = 'patient' | 'user' | 'system';
 export type AccessModifier = 'read' | 'write' | '*';
 export type IdentityType = 'Patient' | 'Practitioner' | 'Person ' | 'RelatedPerson';
 
@@ -42,11 +42,16 @@ export type AccessRule = {
  *          read: ['read','search-type', 'vread'],
  *          write: ['transaction','update', 'patch', 'create'],
  *      },
+ *      system: {
+ *          read: ['read','search-type', 'vread'],
+ *          write: [],
+ *      },
  *  };
  */
 export interface ScopeRule {
     patient: AccessRule;
     user: AccessRule;
+    system: AccessRule;
 }
 
 export type FhirResource = { hostname: string; resourceType: string; id: string };

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -626,8 +626,8 @@ describe('verifyAccessToken; System level export requests', () => {
         );
     });
 
-    test('System scope with no sub set', () => {
-        const decodedAccessToken = { ...baseAccessNoScopes, scp: ['system/*.read'], sub: '' };
+    test.each([['user'], ['system']])('CASE: %p scope with no sub set', baseScope => {
+        const decodedAccessToken = { ...baseAccessNoScopes, scp: [`${baseScope}/*.read`], sub: '' };
         jest.spyOn(smartAuthorizationHelper, 'verifyJwtToken').mockImplementation(() =>
             Promise.resolve(decodedAccessToken),
         );
@@ -641,12 +641,9 @@ describe('verifyAccessToken; System level export requests', () => {
                 accessToken: 'fake',
                 operation: 'read',
                 resourceType: '',
-                bulkDataAuth: { exportType: 'system', operation: 'get-status-export' },
+                bulkDataAuth: { exportType: 'system', operation: 'initiate-export' },
             }),
-        ).resolves.toMatchObject({
-            ...decodedAccessToken,
-            sub: '__system__',
-        });
+        ).rejects.toThrowError(UnauthorizedError);
     });
 });
 

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -36,6 +36,10 @@ const scopeRule = (): ScopeRule => ({
         read: ['read', 'vread', 'search-type', 'search-system', 'history-instance', 'history-type', 'history-system'],
         write: ['create', 'update', 'delete', 'patch', 'transaction', 'batch'],
     },
+    system: {
+        read: ['read', 'vread', 'search-type', 'search-system', 'history-instance', 'history-type', 'history-system'],
+        write: ['create', 'update', 'delete', 'patch', 'transaction', 'batch'],
+    },
 });
 
 const expectedAud = 'api://default';
@@ -379,6 +383,48 @@ describe('verifyAccessToken', () => {
             { ...baseAccessNoScopes, scp: 'user/*.*  patient/*.write' },
             false,
         ],
+        [
+            'system&user&patient_manyWrite_no context or fhirUser',
+            { accessToken: 'fake', operation: 'create', resourceType: 'Patient' },
+            { ...baseAccessNoScopes, scp: 'user/*.*  patient/*.write system/Patient.write' },
+            true,
+        ],
+        [
+            'system_manyRead_Write',
+            { accessToken: 'fake', operation: 'update', resourceType: 'Patient', id: patientId },
+            { ...baseAccessNoScopes, scp: ['system/*.read'] },
+            false,
+        ],
+        [
+            'system_manyRead_Read',
+            { accessToken: 'fake', operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
+            { ...baseAccessNoScopes, scp: ['system/*.read'] },
+            true,
+        ],
+        [
+            'system_ObservationRead_Read',
+            { accessToken: 'fake', operation: 'vread', resourceType: 'Observation', id: '1', vid: '1' },
+            { ...baseAccessNoScopes, scp: 'system/Observation.read' },
+            true,
+        ],
+        [
+            'system_manyRead_search',
+            { accessToken: 'fake', operation: 'search-type', resourceType: 'Observation' },
+            { ...baseAccessNoScopes, scp: 'system/*.read' },
+            true,
+        ],
+        [
+            'system_manyWrite_Read',
+            { accessToken: 'fake', operation: 'read', resourceType: 'Patient', id: patientId },
+            { ...baseAccessNoScopes, scp: 'system/*.write' },
+            false,
+        ],
+        [
+            'system_PatientWrite_create',
+            { accessToken: 'fake', operation: 'create', resourceType: 'Patient' },
+            { ...baseAccessNoScopes, scp: 'system/Patient.write' },
+            true,
+        ],
     ];
 
     const authZConfig = baseAuthZConfig();
@@ -459,7 +505,7 @@ describe('verifyAccessToken; System level export requests', () => {
             false,
         ],
         [
-            'No User read access: initiate-export',
+            'No export read access: cancel-export',
             {
                 accessToken: 'fake',
                 operation: 'read',
@@ -470,7 +516,7 @@ describe('verifyAccessToken; System level export requests', () => {
             false,
         ],
         [
-            'No User access; Patient only: initiate-export',
+            'No export read access; Patient only: cancel-export',
             {
                 accessToken: 'fake',
                 operation: 'read',
@@ -479,6 +525,83 @@ describe('verifyAccessToken; System level export requests', () => {
             },
             { ...baseAccessNoScopes, scp: ['patient/*.*'], ...patientContext },
             false,
+        ],
+        [
+            'System all scope: initiate-export',
+            {
+                accessToken: 'fake',
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'initiate-export' },
+            },
+            { ...baseAccessNoScopes, scp: ['system/*.*'] },
+            true,
+        ],
+        [
+            'System read scope: initiate-export',
+            {
+                accessToken: 'fake',
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'initiate-export' },
+            },
+            { ...baseAccessNoScopes, scp: ['system/*.read'] },
+            true,
+        ],
+        [
+            'System read scope: cancel-export',
+            {
+                accessToken: 'fake',
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'cancel-export' },
+            },
+            { ...baseAccessNoScopes, scp: ['system/*.read'] },
+            true,
+        ],
+        [
+            'System read scope: get-status-export',
+            {
+                accessToken: 'fake',
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'get-status-export' },
+            },
+            { ...baseAccessNoScopes, scp: ['system/*.read'] },
+            true,
+        ],
+        [
+            'System write scope: get-status-export',
+            {
+                accessToken: 'fake',
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'get-status-export' },
+            },
+            { ...baseAccessNoScopes, scp: ['system/*.write'] },
+            false,
+        ],
+        [
+            'System & external practitioner read scope: get-status-export',
+            {
+                accessToken: 'fake',
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'get-status-export' },
+            },
+            { ...baseAccessNoScopes, scp: ['user/*.read', 'system/*.read'], fhirUser: externalPractitionerIdentity },
+            true,
+        ],
+        [
+            'System & internal patient read scope: get-status-export',
+            {
+                accessToken: 'fake',
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'get-status-export' },
+            },
+            { ...baseAccessNoScopes, scp: ['user/*.read', 'system/*.read'], ...patientContext },
+            true,
         ],
     ];
 
@@ -501,6 +624,29 @@ describe('verifyAccessToken; System level export requests', () => {
         return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toMatchObject(
             expectedUserIdentity,
         );
+    });
+
+    test('System scope with no sub set', () => {
+        const decodedAccessToken = { ...baseAccessNoScopes, scp: ['system/*.read'], sub: '' };
+        jest.spyOn(smartAuthorizationHelper, 'verifyJwtToken').mockImplementation(() =>
+            Promise.resolve(decodedAccessToken),
+        );
+        const { decode } = jwt as jest.Mocked<typeof import('jsonwebtoken')>;
+        decode.mockReturnValue(<{ [key: string]: any }>decodedAccessToken);
+
+        const expectedUserIdentity = getExpectedUserIdentity(decodedAccessToken);
+        expectedUserIdentity.scp = decodedAccessToken.scp;
+        return expect(
+            authZHandler.verifyAccessToken({
+                accessToken: 'fake',
+                operation: 'read',
+                resourceType: '',
+                bulkDataAuth: { exportType: 'system', operation: 'get-status-export' },
+            }),
+        ).resolves.toMatchObject({
+            ...decodedAccessToken,
+            sub: '__system__',
+        });
     });
 });
 

--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -626,7 +626,7 @@ describe('verifyAccessToken; System level export requests', () => {
         );
     });
 
-    test.each([['user'], ['system']])('CASE: %p scope with no sub set', baseScope => {
+    test.each([['user'], ['system']])('CASE: %p scope; bulk data request; no sub set in JWT', baseScope => {
         const decodedAccessToken = { ...baseAccessNoScopes, scp: [`${baseScope}/*.read`], sub: '' };
         jest.spyOn(smartAuthorizationHelper, 'verifyJwtToken').mockImplementation(() =>
             Promise.resolve(decodedAccessToken),

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -121,7 +121,6 @@ export class SMARTHandler implements Authorization {
         if (request.bulkDataAuth) {
             if (!userIdentity.sub) {
                 logger.error('A JWT token is without a `sub` claim; we cannot process the bulk action without one.');
-                // if there is a system scope and there is no sub set it to system
                 throw new UnauthorizedError('User does not have permission for requested operation');
             }
             if (

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -126,7 +126,7 @@ export class SMARTHandler implements Authorization {
                     return scope.startsWith('system');
                 })
             ) {
-                // if requrestor is relying on the "user" scope we need to verify they are coming from the correct endpoint & resourceType
+                // if requestor is relying on the "user" scope we need to verify they are coming from the correct endpoint & resourceType
                 const fhirUser = getFhirUser(fhirUserClaim);
                 if (fhirUser.hostname !== this.apiUrl || !this.bulkDataAccessTypes.includes(fhirUser.resourceType)) {
                     throw new UnauthorizedError('User does not have permission for requested operation');

--- a/src/smartScopeHelper.test.ts
+++ b/src/smartScopeHelper.test.ts
@@ -21,8 +21,12 @@ const emptyScopeRule = (): ScopeRule => ({
         read: [],
         write: [],
     },
+    system: {
+        read: [],
+        write: [],
+    },
 });
-const isScopeSufficientCases: ScopeType[][] = [['user'], ['patient']];
+const isScopeSufficientCases: ScopeType[][] = [['user'], ['patient'], ['system']];
 describe.each(isScopeSufficientCases)('%s: isScopeSufficient', (scopeType: ScopeType) => {
     test('scope is sufficient to read Observation: Scope with resourceType "Observation" should be able to read "Observation" resources', () => {
         const clonedScopeRule = emptyScopeRule();
@@ -58,14 +62,14 @@ describe.each(isScopeSufficientCases)('%s: isScopeSufficient', (scopeType: Scope
         );
     });
 
-    test('scope is sufficient for bulk data access with "user" scopeType but not "patient" scopeType', () => {
+    test('scope is sufficient for bulk data access with "user" || "system" scopeType but not "patient" scopeType', () => {
         const clonedScopeRule = emptyScopeRule();
         clonedScopeRule[scopeType].read = ['read'];
         const bulkDataAuth: BulkDataAuth = { operation: 'initiate-export', exportType: 'system' };
 
         // Only scopeType of user has bulkDataAccess
         expect(isScopeSufficient(`${scopeType}/*.read`, clonedScopeRule, 'read', undefined, bulkDataAuth)).toEqual(
-            scopeType === 'user',
+            scopeType !== 'patient',
         );
     });
 
@@ -107,13 +111,19 @@ describe.each(isScopeSufficientCases)('%s: isScopeSufficient', (scopeType: Scope
 
 describe('getScopes', () => {
     test('scope type delimited by space', () => {
-        expect(getScopes('launch/encounter user/*.read fake')).toEqual(['launch/encounter', 'user/*.read', 'fake']);
-    });
-    test('scope type as array', () => {
-        expect(getScopes(['launch/encounter', 'user/*.read', 'fake'])).toEqual([
+        expect(getScopes('launch/encounter user/*.read fake system/*.*')).toEqual([
             'launch/encounter',
             'user/*.read',
             'fake',
+            'system/*.*',
+        ]);
+    });
+    test('scope type as array', () => {
+        expect(getScopes(['launch/encounter', 'user/*.read', 'fake', 'system/*.*'])).toEqual([
+            'launch/encounter',
+            'user/*.read',
+            'fake',
+            'system/*.*',
         ]);
     });
 });
@@ -199,6 +209,25 @@ describe('filterOutUnusableScope', () => {
                 'Patient',
                 undefined,
                 'launchPatient',
+                'fhirUser',
+            ),
+        ).toEqual([expectedScopes[0], expectedScopes[2]]);
+    });
+
+    test('filter system; due to scope being insufficient', () => {
+        const clonedScopeRule = emptyScopeRule();
+        clonedScopeRule.user.read = ['read'];
+        clonedScopeRule.patient.read = ['read'];
+        clonedScopeRule.system.read = ['read'];
+        const expectedScopes = ['user/Patient.read', 'system/Obersvation.*', 'system/*.read'];
+        expect(
+            filterOutUnusableScope(
+                expectedScopes,
+                clonedScopeRule,
+                'read',
+                'Patient',
+                undefined,
+                undefined,
                 'fhirUser',
             ),
         ).toEqual([expectedScopes[0], expectedScopes[2]]);

--- a/src/smartScopeHelper.test.ts
+++ b/src/smartScopeHelper.test.ts
@@ -149,69 +149,37 @@ describe('filterOutUnusableScope', () => {
         const clonedScopeRule = emptyScopeRule();
         clonedScopeRule.user.read = ['read'];
         clonedScopeRule.patient.read = ['read'];
-        const expectedScopes = ['user/*.read', 'user/Patient.read', 'patient/*.*'];
+        const scopes = ['user/*.read', 'user/Patient.read', 'patient/*.*'];
         expect(
-            filterOutUnusableScope(
-                expectedScopes,
-                clonedScopeRule,
-                'read',
-                'Patient',
-                undefined,
-                'launchPatient',
-                undefined,
-            ),
-        ).toEqual([expectedScopes[2]]);
+            filterOutUnusableScope(scopes, clonedScopeRule, 'read', 'Patient', undefined, 'launchPatient', undefined),
+        ).toEqual(['patient/*.*']);
     });
     test('filter user; due to scope being insufficient', () => {
         const clonedScopeRule = emptyScopeRule();
         clonedScopeRule.user.read = ['read'];
         clonedScopeRule.patient.read = ['read'];
-        const expectedScopes = ['user/*.write', 'user/Patient.read', 'patient/*.*'];
+        const scopes = ['user/*.write', 'user/Patient.read', 'patient/*.*'];
         expect(
-            filterOutUnusableScope(
-                expectedScopes,
-                clonedScopeRule,
-                'read',
-                'Patient',
-                undefined,
-                'launchPatient',
-                'fhirUser',
-            ),
-        ).toEqual([expectedScopes[1], expectedScopes[2]]);
+            filterOutUnusableScope(scopes, clonedScopeRule, 'read', 'Patient', undefined, 'launchPatient', 'fhirUser'),
+        ).toEqual(['user/Patient.read', 'patient/*.*']);
     });
     test('filter patient; due to no launch context', () => {
         const clonedScopeRule = emptyScopeRule();
         clonedScopeRule.user.read = ['read'];
         clonedScopeRule.patient.read = ['read'];
-        const expectedScopes = ['user/*.read', 'user/Patient.read', 'patient/*.*'];
+        const scopes = ['user/*.read', 'user/Patient.read', 'patient/*.*'];
         expect(
-            filterOutUnusableScope(
-                expectedScopes,
-                clonedScopeRule,
-                'read',
-                'Patient',
-                undefined,
-                undefined,
-                'fhirUser',
-            ),
-        ).toEqual([expectedScopes[0], expectedScopes[1]]);
+            filterOutUnusableScope(scopes, clonedScopeRule, 'read', 'Patient', undefined, undefined, 'fhirUser'),
+        ).toEqual(['user/*.read', 'user/Patient.read']);
     });
     test('filter patient; due to scope being insufficient', () => {
         const clonedScopeRule = emptyScopeRule();
         clonedScopeRule.user.read = ['read'];
         clonedScopeRule.patient.read = ['read'];
-        const expectedScopes = ['user/Patient.read', 'patient/Obersvation.*', 'patient/*.read'];
+        const scopes = ['user/Patient.read', 'patient/Obersvation.*', 'patient/*.read'];
         expect(
-            filterOutUnusableScope(
-                expectedScopes,
-                clonedScopeRule,
-                'read',
-                'Patient',
-                undefined,
-                'launchPatient',
-                'fhirUser',
-            ),
-        ).toEqual([expectedScopes[0], expectedScopes[2]]);
+            filterOutUnusableScope(scopes, clonedScopeRule, 'read', 'Patient', undefined, 'launchPatient', 'fhirUser'),
+        ).toEqual(['user/Patient.read', 'patient/*.read']);
     });
 
     test('filter system; due to scope being insufficient', () => {
@@ -219,18 +187,10 @@ describe('filterOutUnusableScope', () => {
         clonedScopeRule.user.read = ['read'];
         clonedScopeRule.patient.read = ['read'];
         clonedScopeRule.system.read = ['read'];
-        const expectedScopes = ['user/Patient.read', 'system/Obersvation.*', 'system/*.read'];
+        const scopes = ['user/Patient.read', 'system/Obersvation.*', 'system/*.read'];
         expect(
-            filterOutUnusableScope(
-                expectedScopes,
-                clonedScopeRule,
-                'read',
-                'Patient',
-                undefined,
-                undefined,
-                'fhirUser',
-            ),
-        ).toEqual([expectedScopes[0], expectedScopes[2]]);
+            filterOutUnusableScope(scopes, clonedScopeRule, 'read', 'Patient', undefined, undefined, 'fhirUser'),
+        ).toEqual(['user/Patient.read', 'system/*.read']);
     });
 
     test('filter user & patient', () => {

--- a/src/smartScopeHelper.ts
+++ b/src/smartScopeHelper.ts
@@ -13,10 +13,10 @@ export const SEARCH_OPERATIONS: (TypeOperation | SystemOperation)[] = [
     'history-system',
 ];
 
-export const CLINICAL_SCOPE_REGEX = /^(?<scopeType>patient|user|system)\/(?<scopeResourceType>[A-Z][a-zA-Z]+|\*)\.(?<accessType>read|write|\*)$/;
+export const FHIR_SCOPE_REGEX = /^(?<scopeType>patient|user|system)\/(?<scopeResourceType>[A-Z][a-zA-Z]+|\*)\.(?<accessType>read|write|\*)$/;
 
 export function convertScopeToSmartScope(scope: string): ClinicalSmartScope {
-    const matchClinicalScope = scope.match(CLINICAL_SCOPE_REGEX);
+    const matchClinicalScope = scope.match(FHIR_SCOPE_REGEX);
     if (matchClinicalScope) {
         const { scopeType, scopeResourceType, accessType } = matchClinicalScope.groups!;
 

--- a/src/smartScopeHelper.ts
+++ b/src/smartScopeHelper.ts
@@ -128,7 +128,6 @@ export function isScopeSufficient(
  * Remove scopes that do not have the required information to be useful or unused scopes. For example:
  * - Without the `fhirUser` claim the 'user' scopes cannot be validated
  * - Without the `launch_response_patient` claim the 'patient' scopes cannot be validated
- * - Without `scopeRule.system` defined the `system` scopes will be filtered out
  * - Scopes like profile, launch or fhirUser will be filtered out as well
  */
 export function filterOutUnusableScope(

--- a/src/smartScopeHelper.ts
+++ b/src/smartScopeHelper.ts
@@ -37,10 +37,10 @@ export function getValidOperationsForScopeTypeAndAccessType(
 ): (TypeOperation | SystemOperation)[] {
     let validOperations: (TypeOperation | SystemOperation)[] = [];
     if (accessType === '*' || accessType === 'read') {
-        validOperations = scopeRule[scopeType]?.read || [];
+        validOperations = scopeRule[scopeType].read;
     }
     if (accessType === '*' || accessType === 'write') {
-        validOperations = validOperations.concat(scopeRule[scopeType]?.write || []);
+        validOperations = validOperations.concat(scopeRule[scopeType].write);
     }
     return validOperations;
 }


### PR DESCRIPTION
Description of changes:
- Treat `system` scopes as user scopes as describe:
> System scopes have the format system/(:resourceType|*).(read|write|*)– which conveys the same access scope as the matching user format user/(:resourceType|*).(read|write|*) https://hl7.org/fhir/uv/bulkdata/authorization/index.html#scopes
- Add testing to support new functionality
- In situations with `sub` is not provided in the JWT for system requests; an exception will be thrown

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
