### PR TITLE
feat: allow regex in SMARTConfig.expectedAudValue

### DIFF
--- a/src/smartAuthorizationHelper.test.ts
+++ b/src/smartAuthorizationHelper.test.ts
@@ -456,6 +456,20 @@ describe('verifyJwt', () => {
                 verifyJwtToken(jwt, expectedAudValue, 'https://exampleAuthServer.com/oauth2', client),
             ).resolves.toEqual(payload);
         });
+
+        test('aud provided as RegExp', async () => {
+            const aud = 'api://default';
+            const audRegExp = /api:\/\/([a-z])+/;
+
+            const payload = getDefaultPayload(
+                Math.floor(Date.now() / 1000),
+                Math.floor(Date.now() / 1000) + 10,
+                aud,
+                expectedIssValue,
+            );
+            const jwt = await getSignedJwt(payload);
+            return expect(verifyJwtToken(jwt, audRegExp, expectedIssValue, client)).resolves.toEqual(payload);
+        });
     });
 
     test('iss is incorrect', async () => {

--- a/src/smartAuthorizationHelper.ts
+++ b/src/smartAuthorizationHelper.ts
@@ -119,7 +119,7 @@ export function getJwksClient(jwksUri: string): JwksClient {
 
 export async function verifyJwtToken(
     token: string,
-    expectedAudValue: string,
+    expectedAudValue: string | RegExp,
     expectedIssValue: string,
     client: JwksClient,
 ) {

--- a/src/smartConfig.ts
+++ b/src/smartConfig.ts
@@ -74,6 +74,9 @@ export interface SMARTConfig {
     scopeRule: ScopeRule;
     /**
      * Per SMART spec this is the 'aud' key found in the access_token
+     *
+     * Using the string type is recommended. RegExp can be useful when the audience is not static, such as in multi-tenant setups.
+     * Caution must be taken to avoid overly permissive regular expressions (e.g. avoid using .*). Use regular expressions that are as specific as possible to avoid allowing requests from unexpected audiences.
      */
     expectedAudValue: string | RegExp;
     /**

--- a/src/smartConfig.ts
+++ b/src/smartConfig.ts
@@ -75,7 +75,7 @@ export interface SMARTConfig {
     /**
      * Per SMART spec this is the 'aud' key found in the access_token
      */
-    expectedAudValue: string;
+    expectedAudValue: string | RegExp;
     /**
      * Per SMART spec this is the 'iss' key found in the access_token
      */


### PR DESCRIPTION
Allow RegExp as expectedAudValue.

This enables use cases where the apiUrl is not static. The main use case is for multi-tenancy with tenant-specific urls, but there may be other use cases.

Only minor code changes are required since the `jsonwebtoken` package already accepts `string | RegExp` when verifying the aud value.
https://www.npmjs.com/package/jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback

**Note:** This is intended to support multi-tenancy but it is a generic change so no feature branch is being created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
