### PR TITLE
feat: use fhirServiceBaseUrl from requests if present

### DIFF
--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -212,7 +212,7 @@ const validPatientEncounter = {
 const mock = new MockAdapter(axios);
 beforeEach(() => {
     jest.restoreAllMocks();
-    expect.assertions(1);
+    expect.hasAssertions();
 });
 afterEach(() => {
     mock.reset();
@@ -430,20 +430,38 @@ describe('verifyAccessToken', () => {
     const authZConfig = baseAuthZConfig();
     const authZHandler: SMARTHandler = new SMARTHandler(authZConfig, apiUrl, '4.0.1');
     test.each(cases)('CASE: %p', async (_firstArg, request, decodedAccessToken, isValid) => {
+        const authZHandlerWithAnotherApiURL: SMARTHandler = new SMARTHandler(
+            authZConfig,
+            'https://some-server.com',
+            '4.0.1',
+        );
+
+        const requestWithFhirServiceBaseUrl = { ...request, fhirServiceBaseUrl: apiUrl };
+
         // Handling mocking modules when code is in TS: https://stackoverflow.com/a/60693903/14310364
         jest.spyOn(smartAuthorizationHelper, 'verifyJwtToken').mockImplementation(() =>
             Promise.resolve(decodedAccessToken),
         );
         if (!isValid) {
-            return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).rejects.toThrowError(
+            await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).rejects.toThrowError(
                 UnauthorizedError,
             );
+            await expect(
+                authZHandlerWithAnotherApiURL.verifyAccessToken(
+                    <VerifyAccessTokenRequest>requestWithFhirServiceBaseUrl,
+                ),
+            ).rejects.toThrowError(UnauthorizedError);
+            return;
         }
         const expectedUserIdentity = getExpectedUserIdentity(decodedAccessToken);
 
-        return expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toMatchObject(
+        await expect(authZHandler.verifyAccessToken(<VerifyAccessTokenRequest>request)).resolves.toMatchObject(
             expectedUserIdentity,
         );
+
+        await expect(
+            authZHandlerWithAnotherApiURL.verifyAccessToken(<VerifyAccessTokenRequest>requestWithFhirServiceBaseUrl),
+        ).resolves.toMatchObject(expectedUserIdentity);
     });
 });
 
@@ -918,13 +936,30 @@ describe('authorizeAndFilterReadResponse', () => {
 
     const authZHandler: SMARTHandler = new SMARTHandler(baseAuthZConfig(), apiUrl, '4.0.1');
     test.each(cases)('CASE: %p', async (_firstArg, request, isValid, respBody) => {
+        const authZHandlerWithAnotherApiURL: SMARTHandler = new SMARTHandler(
+            baseAuthZConfig(),
+            'https://some-server.com',
+            '4.0.1',
+        );
+        const requestWithFhirServiceBaseUrl = { ...request, fhirServiceBaseUrl: apiUrl };
+
         if (!isValid) {
             await expect(
                 authZHandler.authorizeAndFilterReadResponse(<ReadResponseAuthorizedRequest>request),
             ).rejects.toThrowError(UnauthorizedError);
+            await expect(
+                authZHandlerWithAnotherApiURL.authorizeAndFilterReadResponse(
+                    <ReadResponseAuthorizedRequest>requestWithFhirServiceBaseUrl,
+                ),
+            ).rejects.toThrowError(UnauthorizedError);
         } else {
             await expect(
                 authZHandler.authorizeAndFilterReadResponse(<ReadResponseAuthorizedRequest>request),
+            ).resolves.toEqual(respBody);
+            await expect(
+                authZHandlerWithAnotherApiURL.authorizeAndFilterReadResponse(
+                    <ReadResponseAuthorizedRequest>requestWithFhirServiceBaseUrl,
+                ),
             ).resolves.toEqual(respBody);
         }
     });
@@ -999,13 +1034,32 @@ describe('isWriteRequestAuthorized', () => {
 
     const authZHandler: SMARTHandler = new SMARTHandler(baseAuthZConfig(), apiUrl, '4.0.1');
     test.each(cases)('CASE: %p', async (_firstArg, request, isValid) => {
+        const authZHandlerWithAnotherApiURL: SMARTHandler = new SMARTHandler(
+            baseAuthZConfig(),
+            'https://some-server.com',
+            '4.0.1',
+        );
+        const requestWithFhirServiceBaseUrl = {
+            ...(<WriteRequestAuthorizedRequest>request),
+            fhirServiceBaseUrl: apiUrl,
+        };
         if (!isValid) {
             await expect(
                 authZHandler.isWriteRequestAuthorized(<WriteRequestAuthorizedRequest>request),
             ).rejects.toThrowError(UnauthorizedError);
+            await expect(
+                authZHandlerWithAnotherApiURL.isWriteRequestAuthorized(
+                    <WriteRequestAuthorizedRequest>requestWithFhirServiceBaseUrl,
+                ),
+            ).rejects.toThrowError(UnauthorizedError);
         } else {
             await expect(
                 authZHandler.isWriteRequestAuthorized(<WriteRequestAuthorizedRequest>request),
+            ).resolves.not.toThrow();
+            await expect(
+                authZHandlerWithAnotherApiURL.isWriteRequestAuthorized(
+                    <WriteRequestAuthorizedRequest>requestWithFhirServiceBaseUrl,
+                ),
             ).resolves.not.toThrow();
         }
     });
@@ -1223,6 +1277,33 @@ describe('getSearchFilterBasedOnIdentity', () => {
         ];
         await expect(authZHandler.getSearchFilterBasedOnIdentity(request)).resolves.toEqual(expectedFilter);
     });
+
+    test('Patient context identity; fhirServiceBaseUrl in request', async () => {
+        const smartHandler: SMARTHandler = new SMARTHandler(baseAuthZConfig(), 'https://some-server.com', '4.0.1');
+        // BUILD
+        const userIdentity = {
+            ...baseAccessNoScopes,
+            scopes: ['patient/*.*', 'user/*.read', 'fhirUser'],
+            patientLaunchContext: getFhirResource(patientId, apiUrl),
+        };
+        const request: GetSearchFilterBasedOnIdentityRequest = {
+            userIdentity,
+            operation: 'search-type',
+            resourceType: 'Encounter',
+            fhirServiceBaseUrl: apiUrl,
+        };
+
+        // OPERATE, CHECK
+        const expectedFilter = [
+            {
+                key: '_references',
+                logicalOperator: 'OR',
+                comparisonOperator: '==',
+                value: [patientIdentity, patientId],
+            },
+        ];
+        await expect(smartHandler.getSearchFilterBasedOnIdentity(request)).resolves.toEqual(expectedFilter);
+    });
     test('User identity', async () => {
         // BUILD
         const userIdentity = {
@@ -1245,6 +1326,32 @@ describe('getSearchFilterBasedOnIdentity', () => {
             },
         ];
         await expect(authZHandler.getSearchFilterBasedOnIdentity(request)).resolves.toEqual(expectedFilter);
+    });
+
+    test('User identity; fhirServiceBaseUrl in request', async () => {
+        const smartHandler: SMARTHandler = new SMARTHandler(baseAuthZConfig(), 'https://some-server.com', '4.0.1');
+        // BUILD
+        const userIdentity = {
+            ...baseAccessNoScopes,
+            scopes: ['patient/*.*', 'user/*.*', 'fhirUser'],
+            fhirUserObject: patientFhirResource,
+        };
+        const request: GetSearchFilterBasedOnIdentityRequest = {
+            userIdentity,
+            operation: 'search-system',
+            fhirServiceBaseUrl: apiUrl,
+        };
+
+        // OPERATE, CHECK
+        const expectedFilter = [
+            {
+                key: '_references',
+                logicalOperator: 'OR',
+                comparisonOperator: '==',
+                value: [patientIdentity, patientId],
+            },
+        ];
+        await expect(smartHandler.getSearchFilterBasedOnIdentity(request)).resolves.toEqual(expectedFilter);
     });
 
     test('User & Patient identity; fhirUser hostname does not match server hostname', async () => {


### PR DESCRIPTION
Description of changes:

Use the `fhirServiceBaseUrl` from the incoming auth request instead of the static `this.apiUrl` set in the constructor.

This package uses the `apiUrl` to perform checks in launch_response/fhirUser claims and when building references to be used in search filters. In a multi-tenant setup the `apiUrl` can be different for each tenant. This change allows the client (i.e. the router package) to specify the api url to be used in the AuthZ check for a given request.

`fhirServiceBaseUrl` takes precedence over `this.apiUrl` as it is more specific(specific to the incoming request). This is a non-breaking change for single tenant setups.

See: 
- https://github.com/awslabs/fhir-works-on-aws-interface/pull/72
- https://github.com/awslabs/fhir-works-on-aws-routing/pull/100

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
