### PR TITLE
fix: support system scope

### DIFF
--- a/src/smartAuthorizationHelper.ts
+++ b/src/smartAuthorizationHelper.ts
@@ -109,6 +109,38 @@ export function hasReferenceToResource(
     );
 }
 
+export function isFhirUserAdmin(fhirUser: FhirResource, adminAccessTypes: string[], apiUrl: string): boolean {
+    return apiUrl === fhirUser.hostname && adminAccessTypes.includes(fhirUser.resourceType);
+}
+
+/**
+ * @param usableScopes this should be usableScope set from the `verifyAccessToken` method
+ * @param resourceType the type of the resource we are trying to access
+ * @returns if there is a usable system scope for this request
+ */
+export function hasSystemAccess(usableScopes: string[], resourceType: string): boolean {
+    return usableScopes.some(
+        (scope: string) => scope.startsWith('system/*') || scope.startsWith(`system/${resourceType}`),
+    );
+}
+
+export function hasAccessToResource(
+    fhirUserObject: FhirResource,
+    patientLaunchContext: FhirResource,
+    sourceResource: any,
+    usableScopes: string[],
+    adminAccessTypes: string[],
+    apiUrl: string,
+    fhirVersion: FhirVersion,
+): boolean {
+    return (
+        hasSystemAccess(usableScopes, sourceResource.resourceType) ||
+        (fhirUserObject &&
+            (isFhirUserAdmin(fhirUserObject, adminAccessTypes, apiUrl) ||
+                hasReferenceToResource(fhirUserObject, sourceResource, apiUrl, fhirVersion))) ||
+        (patientLaunchContext && hasReferenceToResource(patientLaunchContext, sourceResource, apiUrl, fhirVersion))
+    );
+}
 export function getJwksClient(jwksUri: string): JwksClient {
     return jwksClient({
         cache: true,

--- a/src/smartScopeHelper.test.ts
+++ b/src/smartScopeHelper.test.ts
@@ -206,6 +206,20 @@ describe('filterOutUnusableScope', () => {
             ),
         ).toEqual([]);
     });
+
+    test('filter user & patient; transaction use case', () => {
+        const clonedScopeRule = emptyScopeRule();
+        clonedScopeRule.user.read = ['read'];
+        clonedScopeRule.patient.read = ['read'];
+        clonedScopeRule.system.write = ['transaction'];
+        expect(
+            filterOutUnusableScope(
+                ['fhirUser', 'user/Patient.read', 'patient/Obersvation.*', 'patient/*.read', 'system/*.write'],
+                clonedScopeRule,
+                'transaction',
+            ),
+        ).toEqual(['system/*.write']);
+    });
 });
 
 describe('getValidOperationsForScopeTypeAndAccessType', () => {


### PR DESCRIPTION
Description of changes:
- Initial implementation focused solely on it be a valid `scope` in an `access_token`
- This change pushes this `system` functionality to the rest of the package. The changes include
  - `getSearchFilterBasedOnIdentity` -> if `system` scope is found we return no filters (meaning don't filter on an identifier)
  - `isBundleRequestAuthorized` -> filtering to also include the `system` scopes as an option
  - `authorizeAndFilterReadResponse` -> DRY'd up the boolean into `hasAccessToResource` method and allowing the `system` scope
  - `isWriteRequestAuthorized` -> DRY'd up the boolean into `hasAccessToResource` method and allowing the `system` scope

Coverage details:
```bash
-----------------------------|---------|----------|---------|---------|-------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------|---------|----------|---------|---------|-------------------
All files                    |   99.28 |    96.22 |     100 |   99.27 |
 loggerBuilder.ts            |     100 |      100 |     100 |     100 |
 smartAuthorizationHelper.ts |    98.2 |    96.67 |     100 |   98.18 | 237,247
 smartHandler.ts             |     100 |    95.29 |     100 |     100 | 213,279,295,313
 smartScopeHelper.ts         |     100 |     97.5 |     100 |     100 | 62
-----------------------------|---------|----------|---------|---------|-------------------
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
