### PR TITLE
fix: pass params in url for introspect jwt flow

### DIFF
--- a/src/smartAuthorizationHelper.test.ts
+++ b/src/smartAuthorizationHelper.test.ts
@@ -534,7 +534,6 @@ describe('introspectJwtToken', () => {
             introspectJwtToken(jwt, expectedAudValue, expectedIssValue, introspectionOptions),
         ).resolves.toEqual({
             ...payload,
-            active: true,
         });
     });
 

--- a/src/smartAuthorizationHelper.ts
+++ b/src/smartAuthorizationHelper.ts
@@ -212,7 +212,7 @@ export async function introspectJwtToken(
     introspectionOptions: IntrospectionOptions,
 ) {
     // used to verify if `iss` or `aud` is valid
-    decodeJwtToken(token, expectedAudValue, expectedIssValue);
+    const decodedTokenPayload = decodeJwtToken(token, expectedAudValue, expectedIssValue).payload;
     const { introspectUrl, clientId, clientSecret } = introspectionOptions;
 
     // setup basic authentication
@@ -221,22 +221,18 @@ export async function introspectJwtToken(
     const auth = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
 
     try {
-        const response = await axios.post(
-            introspectUrl,
-            { token },
-            {
-                headers: {
-                    'content-type': 'application/x-www-form-urlencoded',
-                    accept: 'application/json',
-                    authorization: auth,
-                    'cache-control': 'no-cache',
-                },
+        const response = await axios.post(introspectUrl, `token=${token}`, {
+            headers: {
+                'content-type': 'application/x-www-form-urlencoded',
+                accept: 'application/json',
+                authorization: auth,
+                'cache-control': 'no-cache',
             },
-        );
+        });
         if (!response.data.active) {
             throw new UnauthorizedError(GENERIC_ERR_MESSAGE);
         }
-        return response.data;
+        return decodedTokenPayload;
     } catch (e) {
         if (axios.isAxiosError(e)) {
             if (e.response) {


### PR DESCRIPTION
Returning the decoded JWT token payload from introspectJwtToken function, and using string token parameter for call to introspect endpoint since it expects x-www-form-urlencoded content-type.

Issue #, if available:

Description of changes:
1. Changed introspectJwtToken method to return the decoded token payload since the introspect endpoint response doesn't necessarily return the JWT. 

For example, our introspect endpoint returns a payload with the "scope" key while the jwt uses "scp". 

2. change the token parameter type to a string for the actual introspect call. The Object structure did not seem to place nice with x-www-form-urlencoded content-type.

3. Updated test to reflect the introspectJwtToken returning the decodedToken payload and not the introspect response.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
