### PR TITLE
fix: pass fhirServiceBaseUrl in bundle request auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
-    "fhir-works-on-aws-interface": "^10.0.0",
+    "fhir-works-on-aws-interface": "^11.0.0",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^1.12.1",
     "lodash": "^4.17.21"

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -268,6 +268,7 @@ export class SMARTHandler implements Authorization {
                     userIdentity: { ...request.userIdentity, usableScopes },
                     operation: req.operation,
                     resourceBody: req.resource,
+                    fhirServiceBaseUrl: request.fhirServiceBaseUrl,
                 });
             }
             return Promise.resolve();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,10 +1981,10 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
   integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
 
-fhir-works-on-aws-interface@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-10.0.0.tgz#5ad0599e55b40c7be1f9ef0cf9252d6da1f8d20a"
-  integrity sha512-JQ/eICquJlI5P6s7e1xiuABnPuhh4d7VeyPFc5OFHgpLbyBCTrbyz0gVMc3BdlQVXQ7IAa0HYgjNsLMoeFt2JA==
+fhir-works-on-aws-interface@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-11.0.0.tgz#96089c99e613a80269472f6510646b46fdc3ddd7"
+  integrity sha512-j25IlOfLHcZtP/zBv1KqsS374cuNqC5JPow5cf+dS4ssdGWnhV0UJsHyk+LvlN601HvcBLAOKJeiU0k5WZcLUg==
   dependencies:
     winston "^3.3.3"
     winston-transport "^4.4.0"


### PR DESCRIPTION
Change related to https://github.com/awslabs/fhir-works-on-aws-interface/pull/78 and https://github.com/awslabs/fhir-works-on-aws-routing/pull/119

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
