### PR TITLE
fix: remove filtered responses from total count

### DIFF
--- a/src/smartHandler.test.ts
+++ b/src/smartHandler.test.ts
@@ -734,6 +734,7 @@ describe('authorizeAndFilterReadResponse', () => {
             lastUpdated: '2020-11-20T11:10:48.034+00:00',
         },
         type: 'searchset',
+        total: 0,
         link: [
             {
                 relation: 'self',
@@ -749,6 +750,7 @@ describe('authorizeAndFilterReadResponse', () => {
     const searchAllEntitiesMatch = {
         ...emptySearchResult,
         entry: [createEntry(validPatient), createEntry(validPatientObservation), createEntry(validPatientEncounter)],
+        total: 3,
     };
 
     const searchSomeEntitiesMatch = {
@@ -760,6 +762,7 @@ describe('authorizeAndFilterReadResponse', () => {
             createEntry({ ...validPatientObservation, subject: 'not-you' }),
             createEntry(validPatientEncounter),
         ],
+        total: 5,
     };
     const searchNoEntitiesMatch = {
         ...emptySearchResult,
@@ -767,6 +770,7 @@ describe('authorizeAndFilterReadResponse', () => {
             createEntry({ ...validPatient, id: 'not-yours' }),
             createEntry({ ...validPatientObservation, subject: 'not-you' }),
         ],
+        total: 2,
     };
     const cases: (string | ReadResponseAuthorizedRequest | boolean | any)[][] = [
         [
@@ -998,7 +1002,7 @@ describe('authorizeAndFilterReadResponse', () => {
                 readResponse: searchAllEntitiesMatch,
             },
             true,
-            { ...emptySearchResult, entry: [createEntry(validPatientEncounter)] },
+            { ...emptySearchResult, entry: [createEntry(validPatientEncounter)], total: 1 },
         ],
         [
             'SEARCH: user scope; Practitioner able to search and get ALL results',

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -318,7 +318,7 @@ export class SMARTHandler implements Authorization {
         const { operation, readResponse } = request;
         // If request is a search treat the readResponse as a bundle
         if (SEARCH_OPERATIONS.includes(operation)) {
-            const entries = (readResponse.entry ?? []).filter((entry: { resource: any }) =>
+            const entries: any[] = (readResponse.entry ?? []).filter((entry: { resource: any }) =>
                 hasAccessToResource(
                     fhirUserObject,
                     patientLaunchContext,
@@ -329,6 +329,10 @@ export class SMARTHandler implements Authorization {
                     this.fhirVersion,
                 ),
             );
+            const totalNumEntriesAfterFilter: number = readResponse.total - (readResponse.entry.length - entries.length);
+            if (totalNumEntriesAfterFilter < readResponse.total) {
+                readResponse.total = totalNumEntriesAfterFilter;
+            }
             return { ...readResponse, entry: entries };
         }
         // If request is != search treat the readResponse as just a resource

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -329,10 +329,8 @@ export class SMARTHandler implements Authorization {
                     this.fhirVersion,
                 ),
             );
-            const totalNumEntriesAfterFilter: number =
-                readResponse.total - (readResponse.entry.length - entries.length);
-            if (totalNumEntriesAfterFilter < readResponse.total) {
-                readResponse.total = totalNumEntriesAfterFilter;
+            if (!Number.isNaN(readResponse.total + 1)) {
+                readResponse.total -= readResponse.entry.length - entries.length;
             }
             return { ...readResponse, entry: entries };
         }

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -329,7 +329,8 @@ export class SMARTHandler implements Authorization {
                     this.fhirVersion,
                 ),
             );
-            const totalNumEntriesAfterFilter: number = readResponse.total - (readResponse.entry.length - entries.length);
+            const totalNumEntriesAfterFilter: number =
+                readResponse.total - (readResponse.entry.length - entries.length);
             if (totalNumEntriesAfterFilter < readResponse.total) {
                 readResponse.total = totalNumEntriesAfterFilter;
             }

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -329,10 +329,13 @@ export class SMARTHandler implements Authorization {
                     this.fhirVersion,
                 ),
             );
-            if (!Number.isNaN(readResponse.total + 1)) {
-                readResponse.total -= readResponse.entry.length - entries.length;
+            let numTotal: number = readResponse.total;
+            if (!numTotal) {
+                numTotal = entries.length;
+            } else {
+                numTotal -= readResponse.entry.length - entries.length;
             }
-            return { ...readResponse, entry: entries };
+            return { ...readResponse, entry: entries, total: numTotal };
         }
         // If request is != search treat the readResponse as just a resource
         if (


### PR DESCRIPTION
Issue #, if available:
#55
Description of changes:
Updated the `authorizeAndFilterReadResponse` method to correctly update the total number of results in a bundle when filtering unauthorized resources.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
