### PR TITLE
fix: scope checking for getting status on an export

### DIFF
--- a/src/smartScopeHelper.test.ts
+++ b/src/smartScopeHelper.test.ts
@@ -136,12 +136,10 @@ describe.each(isScopeSufficientCases)('ScopeType: %s: isScopeSufficient', (scope
                         clonedScopeRule[scopeType].read = ['read'];
                         const bulkDataAuth: BulkDataAuth = { operation, exportType };
 
-                        // Only scopeType of system has bulkDataAccess
                         expect(
                             isScopeSufficient(`${scopeType}/*.read`, clonedScopeRule, 'read', undefined, bulkDataAuth),
                         ).toEqual(scopeType !== 'patient');
 
-                        // Group export result is filtered on allowed resourceType, scope not having resourceType "*" should be passed
                         expect(
                             isScopeSufficient(
                                 `${scopeType}/Observation.read`,

--- a/src/smartScopeHelper.ts
+++ b/src/smartScopeHelper.ts
@@ -84,30 +84,37 @@ function isSmartScopeSufficientForBulkDataAccess(
     smartScope: ClinicalSmartScope,
     scopeRule: ScopeRule,
 ) {
-    let bulkDataRequestHasCorrectScope = false;
-    if (bulkDataAuth.exportType === 'system') {
-        bulkDataRequestHasCorrectScope =
-            ['system', 'user'].includes(smartScope.scopeType) &&
-            smartScope.resourceType === '*' &&
-            ['*', 'read'].includes(smartScope.accessType) &&
-            getValidOperationsForScopeTypeAndAccessType(
-                smartScope.scopeType,
-                smartScope.accessType,
-                scopeRule,
-            ).includes('read');
-    } else if (bulkDataAuth.exportType === 'group') {
-        bulkDataRequestHasCorrectScope =
-            ['system'].includes(smartScope.scopeType) &&
-            ['*', 'read'].includes(smartScope.accessType) &&
-            getValidOperationsForScopeTypeAndAccessType(
-                smartScope.scopeType,
-                smartScope.accessType,
-                scopeRule,
-            ).includes('read');
+    if (bulkDataAuth.operation === 'initiate-export') {
+        let bulkDataRequestHasCorrectScope = false;
+        if (bulkDataAuth.exportType === 'system') {
+            bulkDataRequestHasCorrectScope =
+                ['system', 'user'].includes(smartScope.scopeType) &&
+                smartScope.resourceType === '*' &&
+                ['*', 'read'].includes(smartScope.accessType) &&
+                getValidOperationsForScopeTypeAndAccessType(
+                    smartScope.scopeType,
+                    smartScope.accessType,
+                    scopeRule,
+                ).includes('read');
+        } else if (bulkDataAuth.exportType === 'group') {
+            bulkDataRequestHasCorrectScope =
+                ['system'].includes(smartScope.scopeType) &&
+                ['*', 'read'].includes(smartScope.accessType) &&
+                getValidOperationsForScopeTypeAndAccessType(
+                    smartScope.scopeType,
+                    smartScope.accessType,
+                    scopeRule,
+                ).includes('read');
+        }
+        return bulkDataRequestHasCorrectScope;
     }
     return (
-        ['initiate-export', 'get-status-export', 'cancel-export'].includes(bulkDataAuth.operation) &&
-        bulkDataRequestHasCorrectScope
+        ['get-status-export', 'cancel-export'].includes(bulkDataAuth.operation) &&
+        ['system', 'user'].includes(smartScope.scopeType) &&
+        ['*', 'read'].includes(smartScope.accessType) &&
+        getValidOperationsForScopeTypeAndAccessType(smartScope.scopeType, smartScope.accessType, scopeRule).includes(
+            'read',
+        )
     );
 }
 

--- a/src/smartScopeHelper.ts
+++ b/src/smartScopeHelper.ts
@@ -84,37 +84,24 @@ function isSmartScopeSufficientForBulkDataAccess(
     smartScope: ClinicalSmartScope,
     scopeRule: ScopeRule,
 ) {
+    const { scopeType, accessType, resourceType } = smartScope;
+    const hasReadPermissions = getValidOperationsForScopeTypeAndAccessType(scopeType, accessType, scopeRule).includes(
+        'read',
+    );
     if (bulkDataAuth.operation === 'initiate-export') {
         let bulkDataRequestHasCorrectScope = false;
         if (bulkDataAuth.exportType === 'system') {
             bulkDataRequestHasCorrectScope =
-                ['system', 'user'].includes(smartScope.scopeType) &&
-                smartScope.resourceType === '*' &&
-                ['*', 'read'].includes(smartScope.accessType) &&
-                getValidOperationsForScopeTypeAndAccessType(
-                    smartScope.scopeType,
-                    smartScope.accessType,
-                    scopeRule,
-                ).includes('read');
+                ['system', 'user'].includes(scopeType) && resourceType === '*' && hasReadPermissions;
         } else if (bulkDataAuth.exportType === 'group') {
-            bulkDataRequestHasCorrectScope =
-                ['system'].includes(smartScope.scopeType) &&
-                ['*', 'read'].includes(smartScope.accessType) &&
-                getValidOperationsForScopeTypeAndAccessType(
-                    smartScope.scopeType,
-                    smartScope.accessType,
-                    scopeRule,
-                ).includes('read');
+            bulkDataRequestHasCorrectScope = ['system'].includes(scopeType) && hasReadPermissions;
         }
         return bulkDataRequestHasCorrectScope;
     }
     return (
         ['get-status-export', 'cancel-export'].includes(bulkDataAuth.operation) &&
-        ['system', 'user'].includes(smartScope.scopeType) &&
-        ['*', 'read'].includes(smartScope.accessType) &&
-        getValidOperationsForScopeTypeAndAccessType(smartScope.scopeType, smartScope.accessType, scopeRule).includes(
-            'read',
-        )
+        ['system', 'user'].includes(scopeType) &&
+        hasReadPermissions
     );
 }
 


### PR DESCRIPTION
Description of changes:
- Change scope checking on non - `initiate-export` operations
  - It will now allow if system or user scope
  - This does not change the requirement that the job owner MUST match the requestor id
- removed `['*', 'read'].includes(smartScope.accessType)` check as it was duplicative

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
