### PR TITLE
fix: scopes should not be filtered in search use cases

### DIFF
--- a/src/smartScopeHelper.test.ts
+++ b/src/smartScopeHelper.test.ts
@@ -405,7 +405,7 @@ describe('filterOutUnusableScope', () => {
                 clonedScopeRule,
                 'search-type',
                 false,
-                'DocumentReference'
+                'DocumentReference',
             ),
         ).toEqual(['system/DocumentReference.read', 'system/Patient.read']);
     });

--- a/src/smartScopeHelper.test.ts
+++ b/src/smartScopeHelper.test.ts
@@ -395,6 +395,19 @@ describe('filterOutUnusableScope', () => {
             ),
         ).toEqual(['system/*.write']);
     });
+    
+    test('filter patient in search use case', () => {
+        const clonedScopeRule = emptyScopeRule();
+        clonedScopeRule.system.read = ['search-type'];
+        expect(
+            filterOutUnusableScope(
+                ['system/DocumentReference.read', 'system/Patient.read'],
+                clonedScopeRule,
+                'search-type',
+                false,
+            ),
+        ).toEqual(['system/DocumentReference.read', 'system/Patient.read']);
+    });
 });
 
 describe('getValidOperationsForScopeTypeAndAccessType', () => {

--- a/src/smartScopeHelper.test.ts
+++ b/src/smartScopeHelper.test.ts
@@ -395,7 +395,7 @@ describe('filterOutUnusableScope', () => {
             ),
         ).toEqual(['system/*.write']);
     });
-    
+
     test('filter patient in search use case', () => {
         const clonedScopeRule = emptyScopeRule();
         clonedScopeRule.system.read = ['search-type'];

--- a/src/smartScopeHelper.test.ts
+++ b/src/smartScopeHelper.test.ts
@@ -396,7 +396,7 @@ describe('filterOutUnusableScope', () => {
         ).toEqual(['system/*.write']);
     });
 
-    test('filter patient in search use case', () => {
+    test('do not filter patient scope out in type-search use case', () => {
         const clonedScopeRule = emptyScopeRule();
         clonedScopeRule.system.read = ['search-type'];
         expect(
@@ -405,6 +405,7 @@ describe('filterOutUnusableScope', () => {
                 clonedScopeRule,
                 'search-type',
                 false,
+                'DocumentReference'
             ),
         ).toEqual(['system/DocumentReference.read', 'system/Patient.read']);
     });

--- a/src/smartScopeHelper.ts
+++ b/src/smartScopeHelper.ts
@@ -62,7 +62,7 @@ function getValidOperationsForScope(
     // 'search-system' and 'history-system' request operation requires '*' for scopeResourceType
     else if (
         (['search-system', 'history-system'].includes(reqOperation) && resourceType === '*') ||
-        ['transaction', 'batch'].includes(reqOperation)
+        ['transaction', 'batch', 'search-type'].includes(reqOperation)
     ) {
         validOperations = getValidOperationsForScopeTypeAndAccessType(scopeType, accessType, scopeRule);
     }

--- a/src/smartScopeHelper.ts
+++ b/src/smartScopeHelper.ts
@@ -55,14 +55,14 @@ function getValidOperationsForScope(
     let validOperations: (TypeOperation | SystemOperation)[] = [];
     const { scopeType, resourceType, accessType } = smartScope;
     if (reqResourceType) {
-        if (resourceType === '*' || resourceType === reqResourceType) {
+        if (resourceType === '*' || resourceType === reqResourceType || reqOperation === 'search-type') {
             validOperations = getValidOperationsForScopeTypeAndAccessType(scopeType, accessType, scopeRule);
         }
     }
     // 'search-system' and 'history-system' request operation requires '*' for scopeResourceType
     else if (
         (['search-system', 'history-system'].includes(reqOperation) && resourceType === '*') ||
-        ['transaction', 'batch', 'search-type'].includes(reqOperation)
+        ['transaction', 'batch'].includes(reqOperation)
     ) {
         validOperations = getValidOperationsForScopeTypeAndAccessType(scopeType, accessType, scopeRule);
     }


### PR DESCRIPTION
Issue #78 , if available:

Description of changes:
Updated the function checking valid operations for scope to process search use cases similar to transactions/batches. This means that searches running include will contain all expected resources and not drop scopes to limit search results since they are not directly requested.

**Testing**
To test that the functionality was working as intended, I deployed on SMART and created a `DocumentReference` with a reference to a `Patient` resource, and searched with the example scopes (`system/DocumentReference.read`, `system/Patient.read`) to reproduce the issue. I then implemented the fix as well as an additional unit test, and made sure that the Patient resource was included in the search results.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
