### PR TITLE
fix: handle include/revInclude correctly

### DIFF
--- a/src/smartAuthorizationHelper.test.ts
+++ b/src/smartAuthorizationHelper.test.ts
@@ -542,7 +542,7 @@ describe('introspectJwtToken', () => {
             Math.floor(Date.now() / 1000),
             Math.floor(Date.now() / 1000) + 10,
             expectedAudValue,
-            `${expectedIssValue}/`,
+            `${expectedIssValue}`,
         );
         const mock = new MockAdapter(axios);
         mock.onPost(introspectUrl).reply(200, {

--- a/src/smartAuthorizationHelper.ts
+++ b/src/smartAuthorizationHelper.ts
@@ -118,9 +118,9 @@ export function isFhirUserAdmin(fhirUser: FhirResource, adminAccessTypes: string
 }
 
 /**
- * @param scopes this should be scope set from the `verifyAccessToken` method
- * @param resourceType the type of the resource the request is trying to access
- * @param accessModifier the type of access the request is asking for
+ * @param scopes: this should be scope set from the `verifyAccessToken` method
+ * @param resourceType: the type of the resource the request is trying to access
+ * @param accessModifier: the type of access the request is asking for
  * @returns if there is a usable system scope for this request
  */
 export function hasSystemAccess(scopes: string[], resourceType: string, accessModifier: AccessModifier): boolean {
@@ -135,6 +135,7 @@ export function hasSystemAccess(scopes: string[], resourceType: string, accessMo
             );
         } catch (e) {
             // Error occurs from `convertScopeToSmartScope` if scope was invalid
+            logger.debug((e as any).message);
             return false;
         }
     });

--- a/src/smartAuthorizationHelper.ts
+++ b/src/smartAuthorizationHelper.ts
@@ -8,7 +8,9 @@ import { decode, verify } from 'jsonwebtoken';
 import axios from 'axios';
 import resourceReferencesMatrixV4 from './schema/fhirResourceReferencesMatrix.v4.0.1.json';
 import resourceReferencesMatrixV3 from './schema/fhirResourceReferencesMatrix.v3.0.1.json';
-import { FhirResource, IntrospectionOptions } from './smartConfig';
+import { AccessModifier, FhirResource, IntrospectionOptions } from './smartConfig';
+import { convertScopeToSmartScope } from './smartScopeHelper';
+
 import getComponentLogger from './loggerBuilder';
 
 export const FHIR_USER_REGEX =
@@ -116,14 +118,26 @@ export function isFhirUserAdmin(fhirUser: FhirResource, adminAccessTypes: string
 }
 
 /**
- * @param usableScopes this should be usableScope set from the `verifyAccessToken` method
- * @param resourceType the type of the resource we are trying to access
+ * @param scopes this should be scope set from the `verifyAccessToken` method
+ * @param resourceType the type of the resource the request is trying to access
+ * @param accessModifier the type of access the request is asking for
  * @returns if there is a usable system scope for this request
  */
-export function hasSystemAccess(usableScopes: string[], resourceType: string): boolean {
-    return usableScopes.some(
-        (scope: string) => scope.startsWith('system/*') || scope.startsWith(`system/${resourceType}`),
-    );
+export function hasSystemAccess(scopes: string[], resourceType: string, accessModifier: AccessModifier): boolean {
+    return scopes.some((scope: string) => {
+        try {
+            const clinicalSmartScope = convertScopeToSmartScope(scope);
+
+            return (
+                clinicalSmartScope.scopeType === 'system' &&
+                (clinicalSmartScope.resourceType === '*' || clinicalSmartScope.resourceType === resourceType) &&
+                (clinicalSmartScope.accessType === '*' || clinicalSmartScope.accessType === accessModifier)
+            );
+        } catch (e) {
+            // Error occurs from `convertScopeToSmartScope` if scope was invalid
+            return false;
+        }
+    });
 }
 
 export function hasAccessToResource(
@@ -134,9 +148,10 @@ export function hasAccessToResource(
     adminAccessTypes: string[],
     apiUrl: string,
     fhirVersion: FhirVersion,
+    accessModifier: AccessModifier,
 ): boolean {
     return (
-        hasSystemAccess(usableScopes, sourceResource.resourceType) ||
+        hasSystemAccess(usableScopes, sourceResource.resourceType, accessModifier) ||
         (fhirUserObject &&
             (isFhirUserAdmin(fhirUserObject, adminAccessTypes, apiUrl) ||
                 hasReferenceToResource(fhirUserObject, sourceResource, apiUrl, fhirVersion))) ||

--- a/src/smartHandler.ts
+++ b/src/smartHandler.ts
@@ -69,10 +69,10 @@ export class SMARTHandler implements Authorization {
     private readonly jwksClient?: JwksClient;
 
     /**
-     * @param apiUrl URL of this FHIR service. Will be used to determine if a requestor is from this FHIR server or not
+     * @param apiUrl: URL of this FHIR service. Will be used to determine if a requestor is from this FHIR server or not
      * when the request does not include a fhirServiceBaseUrl
-     * @param adminAccessTypes a fhirUser from these resourceTypes they will be able to READ & WRITE without having to meet the reference criteria
-     * @param bulkDataAccessTypes a fhirUser from these resourceTypes they will be able to do bulk data operations
+     * @param adminAccessTypes: a fhirUser from these resourceTypes they will be able to READ & WRITE without having to meet the reference criteria
+     * @param bulkDataAccessTypes: a fhirUser from these resourceTypes they will be able to do bulk data operations
      */
     constructor(
         config: SMARTConfig,
@@ -316,6 +316,7 @@ export class SMARTHandler implements Authorization {
                 }
             } catch (e) {
                 // Caused by trying to convert non-SmartScope to SmartScope, for example converting scope 'openid' or 'profile'
+                logger.debug((e as any).message);
             }
         }
         allowedResources = [...new Set(allowedResources)];

--- a/src/smartScopeHelper.test.ts
+++ b/src/smartScopeHelper.test.ts
@@ -118,11 +118,23 @@ describe.each(isScopeSufficientCases)('ScopeType: %s: isScopeSufficient', (scope
 
         expect(isScopeSufficient(`${scopeType}/*.read`, clonedScopeRule, 'search-system', false)).toEqual(true);
     });
+    test('scope is sufficient to do a history-system', () => {
+        const clonedScopeRule = emptyScopeRule();
+        clonedScopeRule[scopeType].read = ['history-system'];
+
+        expect(isScopeSufficient(`${scopeType}/*.read`, clonedScopeRule, 'history-system', false)).toEqual(true);
+    });
     test('scope is sufficient to do a transaction', () => {
         const clonedScopeRule = emptyScopeRule();
         clonedScopeRule[scopeType].write = ['transaction'];
 
         expect(isScopeSufficient(`${scopeType}/*.write`, clonedScopeRule, 'transaction', false)).toEqual(true);
+    });
+    test('scope is sufficient to do a batch', () => {
+        const clonedScopeRule = emptyScopeRule();
+        clonedScopeRule[scopeType].write = ['batch'];
+
+        expect(isScopeSufficient(`${scopeType}/*.write`, clonedScopeRule, 'batch', false)).toEqual(true);
     });
     test('scope is insufficient to do a transaction', () => {
         const clonedScopeRule = emptyScopeRule();
@@ -131,11 +143,11 @@ describe.each(isScopeSufficientCases)('ScopeType: %s: isScopeSufficient', (scope
 
         expect(isScopeSufficient(`${scopeType}/*.*`, clonedScopeRule, 'transaction', false)).toEqual(false);
     });
-    test('invalid scope', () => {
+    test('invalid; `read` scope with no resourcType', () => {
         const clonedScopeRule = emptyScopeRule();
         clonedScopeRule[scopeType].read = ['read'];
 
-        expect(isScopeSufficient(`fake`, clonedScopeRule, 'read', false)).toEqual(false);
+        expect(isScopeSufficient(`${scopeType}/Patient.*`, clonedScopeRule, 'read', false)).toEqual(false);
     });
 
     describe('BulkDataAuth', () => {
@@ -148,6 +160,16 @@ describe.each(isScopeSufficientCases)('ScopeType: %s: isScopeSufficient', (scope
             expect(
                 isScopeSufficient(`${scopeType}/*.read`, clonedScopeRule, 'read', true, undefined, bulkDataAuth),
             ).toEqual(scopeType !== 'patient');
+        });
+        test('initiate-export: exportType is undefined; should fail', () => {
+            const clonedScopeRule = emptyScopeRule();
+            clonedScopeRule[scopeType].read = ['read'];
+            const bulkDataAuth: BulkDataAuth = { operation: 'initiate-export' };
+
+            // Only scopeType of user has bulkDataAccess
+            expect(
+                isScopeSufficient(`${scopeType}/*.read`, clonedScopeRule, 'read', true, undefined, bulkDataAuth),
+            ).toEqual(false);
         });
 
         test('scope is NOT sufficient for `system` initiate-export: Scope needs to have resourceType "*"', () => {
@@ -252,6 +274,12 @@ describe.each(isScopeSufficientCases)('ScopeType: %s: isScopeSufficient', (scope
             );
         });
     });
+});
+test('isScopeSufficient: invalid scope non-smart', () => {
+    const clonedScopeRule = emptyScopeRule();
+    clonedScopeRule.system.read = ['read'];
+
+    expect(isScopeSufficient(`fhirUser`, clonedScopeRule, 'read', false)).toEqual(false);
 });
 
 describe('getScopes', () => {
@@ -420,6 +448,9 @@ describe('filterOutUnusableScope', () => {
                 'search-type',
                 false,
                 'Practitioner',
+                undefined,
+                undefined,
+                'fhirUser',
             ),
         ).toEqual([]);
     });
@@ -433,10 +464,12 @@ describe('filterOutUnusableScope', () => {
                 'search-type',
                 false,
                 'Practitioner',
+                undefined,
+                'patient',
             ),
         ).toEqual([]);
     });
-    test('do not filter patient scope out in type-search use case', () => {
+    test('SYSTEM Scope: do filter Patient resourceType scope out in type-search use case', () => {
         const clonedScopeRule = emptyScopeRule();
         clonedScopeRule.system.read = ['search-type'];
         expect(
@@ -447,7 +480,38 @@ describe('filterOutUnusableScope', () => {
                 false,
                 'DocumentReference',
             ),
-        ).toEqual(['system/DocumentReference.read', 'system/Patient.read']);
+        ).toEqual(['system/DocumentReference.read']);
+    });
+    test('USER Scope: do filter Patient resourceType scope out in type-search use case', () => {
+        const clonedScopeRule = emptyScopeRule();
+        clonedScopeRule.user.read = ['search-type'];
+        expect(
+            filterOutUnusableScope(
+                ['user/DocumentReference.read', 'user/Patient.read'],
+                clonedScopeRule,
+                'search-type',
+                false,
+                'DocumentReference',
+                undefined,
+                undefined,
+                'fhirUser',
+            ),
+        ).toEqual(['user/DocumentReference.read']);
+    });
+    test('PATIENT Scope: do filter Patient resourceType scope out in type-search use case', () => {
+        const clonedScopeRule = emptyScopeRule();
+        clonedScopeRule.patient.read = ['search-type'];
+        expect(
+            filterOutUnusableScope(
+                ['patient/DocumentReference.read', 'patient/Patient.read'],
+                clonedScopeRule,
+                'search-type',
+                false,
+                'DocumentReference',
+                undefined,
+                'patient',
+            ),
+        ).toEqual(['patient/DocumentReference.read']);
     });
 });
 

--- a/src/smartScopeHelper.test.ts
+++ b/src/smartScopeHelper.test.ts
@@ -143,7 +143,7 @@ describe.each(isScopeSufficientCases)('ScopeType: %s: isScopeSufficient', (scope
 
         expect(isScopeSufficient(`${scopeType}/*.*`, clonedScopeRule, 'transaction', false)).toEqual(false);
     });
-    test('invalid; `read` scope with no resourcType', () => {
+    test('invalid; `read` scope with no resourceType', () => {
         const clonedScopeRule = emptyScopeRule();
         clonedScopeRule[scopeType].read = ['read'];
 

--- a/src/smartScopeHelper.ts
+++ b/src/smartScopeHelper.ts
@@ -55,7 +55,7 @@ function getValidOperationsForScope(
     let validOperations: (TypeOperation | SystemOperation)[] = [];
     const { scopeType, resourceType, accessType } = smartScope;
     if (reqResourceType) {
-        if (resourceType === '*' || resourceType === reqResourceType || reqOperation === 'search-type') {
+        if (resourceType === '*' || resourceType === reqResourceType) {
             validOperations = getValidOperationsForScopeTypeAndAccessType(scopeType, accessType, scopeRule);
         }
     }
@@ -171,17 +171,6 @@ export function filterOutUnusableScope(
                 bulkDataAuth,
             ),
     );
-
-    // We should only return the scopes iff there is at least 1 valid scope for the given resourceType
-    if (
-        reqOperation === 'search-type' &&
-        !filteredScopes.some((scope: string) => {
-            const smartScope = convertScopeToSmartScope(scope);
-            return smartScope.resourceType === '*' || smartScope.resourceType === reqResourceType;
-        })
-    ) {
-        return [];
-    }
 
     return filteredScopes;
 }

--- a/src/smartScopeHelper.ts
+++ b/src/smartScopeHelper.ts
@@ -4,6 +4,9 @@
  */
 import { BulkDataAuth, SystemOperation, TypeOperation } from 'fhir-works-on-aws-interface';
 import { AccessModifier, ClinicalSmartScope, ScopeRule, ScopeType } from './smartConfig';
+import getComponentLogger from './loggerBuilder';
+
+const logger = getComponentLogger();
 
 export const SEARCH_OPERATIONS: (TypeOperation | SystemOperation)[] = [
     'search-type',
@@ -136,6 +139,7 @@ export function isScopeSufficient(
         return validOperations.includes(reqOperation);
     } catch (e) {
         // Caused by trying to convert non-SmartScope to SmartScope, for example converting non-SMART scope 'openid'
+        logger.debug((e as any).message);
     }
 
     return false;


### PR DESCRIPTION
Issue #, if available: #83

Description of changes:
- Moving the logic of dealing with non-root resourceTypes returned from a `search-type` operation from `filterOutUnusableScope` to `authorizeAndFilterReadResponse`
- Make `hasSystemAccess` more explicit
- Improve test coverage

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
